### PR TITLE
[56][Bug] Fixing Double select and Link props

### DIFF
--- a/src/components/core/Button/Button.tsx
+++ b/src/components/core/Button/Button.tsx
@@ -2,7 +2,6 @@ import clsx from "clsx";
 import { forwardRef } from "react";
 
 const sizes = {
-  xs: "px-2 py-1 text-xs rounded",
   sm: "px-2 py-1 text-sm rounded",
   md: "px-2.5 py-1.5 text-sm rounded-md",
   lg: "px-3 py-2 text-sm rounded-md",
@@ -16,7 +15,6 @@ const variants = {
     "bg-white text-blue-600 hover:bg-gray-100 focus-visible:outline-gray-200 border border-gray-200",
   danger:
     "bg-red-600 text-white hover:bg-red-500 focus-visible:outline-red-600",
-  info: "bg-yellow-600 text-white hover:bg-yellow-500 focus-visible:outline-yellow-600",
 };
 
 type IconProps =
@@ -33,13 +31,13 @@ type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
-      type = "button",
       className = "",
+      type = "button",
       variant = "primary",
       size = "md",
       isLoading = false,
-      startIcon,
       endIcon,
+      startIcon,
       ...props
     },
     ref,

--- a/src/components/core/Button/LinkButton.tsx
+++ b/src/components/core/Button/LinkButton.tsx
@@ -1,14 +1,54 @@
-import { Link } from "react-router-dom";
-import { Button } from "./Button";
+import clsx from "clsx";
+import { Link, LinkProps } from "react-router-dom";
 
-type LinkButtonProps = React.ComponentProps<typeof Button> & {
-  to: string;
+const sizes = {
+  sm: "px-2 py-1 text-sm rounded",
+  md: "px-2.5 py-1.5 text-sm rounded-md",
+  lg: "px-3 py-2 text-sm rounded-md",
+  xl: "px-3.5 py-2.5 text-sm rounded-md",
 };
 
-export const LinkButton = ({ to, ...props }: LinkButtonProps) => {
+const variants = {
+  primary:
+    "bg-blue-600 text-white hover:bg-blue-500 focus-visible:outline-blue-600",
+  secondary:
+    "bg-white text-blue-600 hover:bg-gray-100 focus-visible:outline-gray-200 border border-gray-200",
+  danger:
+    "bg-red-600 text-white hover:bg-red-500 focus-visible:outline-red-600",
+};
+
+type IconProps =
+  | { startIcon: React.ReactElement; endIcon?: never }
+  | { endIcon: React.ReactElement; startIcon?: never }
+  | { endIcon?: undefined; startIcon?: undefined };
+
+type StyleProps = {
+  variant?: keyof typeof variants;
+  size?: keyof typeof sizes;
+} & IconProps;
+
+type Props = StyleProps & LinkProps;
+
+export const LinkButton = ({
+  size = "md",
+  variant = "primary",
+  className,
+  endIcon,
+  startIcon,
+  ...props
+}: Props) => {
   return (
-    <Link to={to} className="w-full">
-      <Button {...props}>{props.children}</Button>
+    <Link
+      {...props}
+      className={clsx(
+        "inline-flex items-center font-semibold shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2",
+        variants[variant],
+        sizes[size],
+        className,
+      )}>
+      {startIcon}
+      <span className="mx-2">{props.children}</span>
+      {endIcon}
     </Link>
   );
 };

--- a/src/experiments/RHF/useFieldArray/LastExample.tsx
+++ b/src/experiments/RHF/useFieldArray/LastExample.tsx
@@ -143,7 +143,7 @@ export const LastExample = () => {
                 {index > 0 && (
                   <Button
                     variant="danger"
-                    size="xs"
+                    size="sm"
                     className="mt-1"
                     onClick={() => remove(index)}>
                     {`Delete Project ${index + 1}`}

--- a/src/experiments/RHF/useFieldArray/MyFirst.tsx
+++ b/src/experiments/RHF/useFieldArray/MyFirst.tsx
@@ -143,7 +143,7 @@ export const MyFirst = () => {
                 {index > 0 && (
                   <Button
                     variant="danger"
-                    size="xs"
+                    size="sm"
                     className="mt-1"
                     onClick={() => remove(index)}>
                     {`Delete Project ${index + 1}`}


### PR DESCRIPTION
## Change Description 
- Fixing double select in `<LinkButton/>` due to `<Link/>` nesting a `<Button/>` component.
- Removed the "xs" size in buttons due to it not feeling well on Mobile.
- Remove "info" variant as it didn't fit the page styling.

## Type of Change 
- [X] Bug Fix 
- [ ] New Feature 
- [ ] Refactor 
- [ ] Documentation Improvement 
- [ ] Other (specify: _______) 

## Verification 
- [ ] The pull request depends on another pull request 
- [X] All existing tests pass after the changes. 
- [ ] New tests have been added to cover the changes (if applicable). 
- [ ] Documentation has been updated to reflect the changes (if applicable). 
- [ ] The feature works as expected and meets the acceptance criteria. 