### PR TITLE
[66] useId replacing all data-test-id and improve accessibility

### DIFF
--- a/src/components/form/FileInput/FileInput.tsx
+++ b/src/components/form/FileInput/FileInput.tsx
@@ -1,8 +1,7 @@
-//TODO: Add ability to drop files
+import { useId } from "react";
 import { ExclamationCircleIcon } from "@heroicons/react/20/solid";
 import { UseFormRegisterReturn } from "react-hook-form";
 import { PhotoIcon } from "@heroicons/react/24/outline";
-import { transformLabel } from "@/components/utils";
 import { InputWrapperPassProps } from "..";
 import { clsx } from "clsx";
 
@@ -25,7 +24,10 @@ export const FileInput = ({
   showAsterisk = false,
   accept = ".jpg, .jpeg, .png",
 }: FileProps) => {
-  const inputUniqueId = `file-input-${transformLabel(label)}`;
+  const id = useId();
+  const inputUniqueId = `file-input-${id}`;
+  const descriptionId = `file-input-description-${id}`;
+  const errorId = `file-input-error-${id}`;
 
   return (
     <div className={clsx("col-span-full", className)}>
@@ -59,12 +61,13 @@ export const FileInput = ({
               <span>Upload a file</span>
               <input
                 id={inputUniqueId}
-                data-testid={inputUniqueId}
                 type="file"
                 className="sr-only"
                 multiple={multiple}
                 accept={accept}
                 {...registration}
+                aria-describedby={error ? errorId : descriptionId}
+                aria-invalid={Boolean(error)}
               />
             </label>
             <p className="pl-1">or drag and drop</p>
@@ -87,10 +90,15 @@ export const FileInput = ({
 
       {/* Error & Description */}
       {description && !error && (
-        <p className="mt-2 text-sm font-light text-gray-500">{description}</p>
+        <p id={descriptionId} className="mt-2 text-sm font-light text-gray-500">
+          {description}
+        </p>
       )}
       {error && (
-        <p role="alert" className="mt-2 text-sm font-light text-red-600">
+        <p
+          id={errorId}
+          role="alert"
+          className="mt-2 text-sm font-light text-red-600">
           {error}
         </p>
       )}

--- a/src/components/form/InputWrapper/InputWrapper.tsx
+++ b/src/components/form/InputWrapper/InputWrapper.tsx
@@ -8,7 +8,9 @@ type InputWrapperProps = {
   showAsterisk?: boolean;
   children: React.ReactNode;
   description?: string;
+  descriptionId?: string;
   error?: string;
+  errorId?: string;
 };
 
 export type InputWrapperPassProps = Omit<InputWrapperProps, "children">;
@@ -20,7 +22,9 @@ export const InputWrapper = ({
   showAsterisk,
   children,
   description,
+  descriptionId,
   error,
+  errorId,
 }: InputWrapperProps) => {
   return (
     <div className={clsx(wrapperClassName)}>
@@ -44,10 +48,15 @@ export const InputWrapper = ({
         </div>
       </label>
       {description && !error && (
-        <p className="mt-2 text-sm font-light text-gray-500">{description}</p>
+        <p id={descriptionId} className="mt-2 text-sm font-light text-gray-500">
+          {description}
+        </p>
       )}
       {error && (
-        <p role="alert" className="mt-2 text-sm font-light text-red-600">
+        <p
+          id={errorId}
+          role="alert"
+          className="mt-2 text-sm font-light text-red-600">
           {error}
         </p>
       )}

--- a/src/components/form/NumerInput/NumberInput.tsx
+++ b/src/components/form/NumerInput/NumberInput.tsx
@@ -1,6 +1,6 @@
+import { useId } from "react";
 import { ExclamationCircleIcon } from "@heroicons/react/20/solid";
 import { UseFormRegisterReturn } from "react-hook-form";
-import { transformLabel } from "@/components/utils";
 import { clsx } from "clsx";
 
 type InputProps = {
@@ -22,7 +22,9 @@ export const NumberInput = ({
   description,
   error,
 }: InputProps) => {
-  const inputUniqueId = `numeric-input-${transformLabel(label)}`;
+  const id = useId();
+  const descriptionId = `number-input-description-${id}`;
+  const errorId = `number-input-error-${id}`;
 
   return (
     <div className={clsx(className)}>
@@ -31,10 +33,9 @@ export const NumberInput = ({
         {showAsterisk && <span className="ml-1 text-red-700">*</span>}
         <div className="relative mt-2">
           <input
-            id={inputUniqueId}
-            data-testid={inputUniqueId}
             type="number"
             placeholder={placeholder}
+            aria-describedby={error ? errorId : descriptionId}
             aria-invalid={Boolean(error)}
             {...registration}
             className={clsx(
@@ -56,10 +57,15 @@ export const NumberInput = ({
         </div>
       </label>
       {description && !error && (
-        <p className="mt-2 text-sm font-light text-gray-500">{description}</p>
+        <p id={descriptionId} className="mt-2 text-sm font-light text-gray-500">
+          {description}
+        </p>
       )}
       {error && (
-        <p role="alert" className="mt-2 text-sm font-light text-red-600">
+        <p
+          id={errorId}
+          role="alert"
+          className="mt-2 text-sm font-light text-red-600">
           {error}
         </p>
       )}

--- a/src/components/form/Select/Select.tsx
+++ b/src/components/form/Select/Select.tsx
@@ -1,6 +1,6 @@
+import { useId } from "react";
 import { ExclamationCircleIcon } from "@heroicons/react/20/solid";
 import { UseFormRegisterReturn } from "react-hook-form";
-import { transformLabel } from "@/components/utils";
 import { Option } from "@/types/core";
 import { clsx } from "clsx";
 
@@ -25,7 +25,10 @@ export const Select = ({
   error,
   options,
 }: SelectProps) => {
-  const inputUniqueId = `select-input-${transformLabel(label)}`;
+  const id = useId();
+  const inputUniqueId = `select-input-${id}`;
+  const descriptionId = `select-input-description-${id}`;
+  const errorId = `select-input-error-${id}`;
 
   return (
     <div className={clsx(className)}>
@@ -39,8 +42,9 @@ export const Select = ({
       <div className="relative mt-2">
         <select
           id={inputUniqueId}
-          data-testid={inputUniqueId}
           {...registration}
+          aria-describedby={error ? errorId : descriptionId}
+          aria-invalid={Boolean(error)}
           className={clsx(
             "mt-2 block w-full rounded-md border-0 py-1.5 pl-3 pr-10 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6",
             error &&
@@ -67,10 +71,15 @@ export const Select = ({
       </div>
 
       {description && !error && (
-        <p className="mt-2 text-sm font-light text-gray-500">{description}</p>
+        <p id={descriptionId} className="mt-2 text-sm font-light text-gray-500">
+          {description}
+        </p>
       )}
       {error && (
-        <p role="alert" className="mt-2 text-sm font-light text-red-600">
+        <p
+          id={errorId}
+          role="alert"
+          className="mt-2 text-sm font-light text-red-600">
           {error}
         </p>
       )}

--- a/src/components/form/TextArea/TextArea.tsx
+++ b/src/components/form/TextArea/TextArea.tsx
@@ -1,6 +1,6 @@
+import { useId } from "react";
 import { UseFormRegisterReturn } from "react-hook-form";
 import { InputWrapper, InputWrapperPassProps } from "..";
-import { transformLabel } from "@/components/utils";
 import { clsx } from "clsx";
 
 const sizes = {
@@ -30,7 +30,10 @@ export function TextArea({
   placeholder,
   disabled,
 }: Props) {
-  const inputUniqueId = `textarea-input-${transformLabel(label)}`;
+  const id = useId();
+  const inputUniqueId = `file-input-${id}`;
+  const descriptionId = `file-input-description-${id}`;
+  const errorId = `file-input-error-${id}`;
 
   return (
     <InputWrapper
@@ -39,14 +42,17 @@ export function TextArea({
       label={label}
       showAsterisk={showAsterisk}
       description={description}
-      error={error}>
+      descriptionId={descriptionId}
+      error={error}
+      errorId={errorId}>
       <textarea
         id={inputUniqueId}
-        data-testid={inputUniqueId}
         rows={sizes[size]}
         disabled={disabled}
         placeholder={placeholder}
         {...registration}
+        aria-describedby={error ? errorId : descriptionId}
+        aria-invalid={Boolean(error)}
         className={clsx(
           "block w-full rounded-md border-0 py-1.5 text-sm font-light text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:leading-6",
           "disabled:cursor-not-allowed disabled:bg-gray-50 disabled:text-gray-500 disabled:ring-gray-200",

--- a/src/components/form/TextInput/TextInput.tsx
+++ b/src/components/form/TextInput/TextInput.tsx
@@ -1,6 +1,6 @@
+import { useId } from "react";
 import { UseFormRegisterReturn } from "react-hook-form";
 import { InputWrapper, InputWrapperPassProps } from "..";
-import { transformLabel } from "@/components/utils";
 import { clsx } from "clsx";
 
 type Types = "text" | "password" | "email" | "search" | "url";
@@ -25,7 +25,10 @@ export const TextInput = ({
   description,
   error,
 }: InputProps) => {
-  const inputUniqueId = `text-input-${transformLabel(label)}`;
+  const id = useId();
+  const inputUniqueId = `file-input-${id}`;
+  const descriptionId = `file-input-description-${id}`;
+  const errorId = `file-input-error-${id}`;
 
   return (
     <InputWrapper
@@ -34,13 +37,15 @@ export const TextInput = ({
       label={label}
       showAsterisk={showAsterisk}
       description={description}
-      error={error}>
+      descriptionId={descriptionId}
+      error={error}
+      errorId={errorId}>
       <input
         id={inputUniqueId}
-        data-testid={inputUniqueId}
         type={type}
         disabled={disabled}
         placeholder={placeholder}
+        aria-describedby={error ? errorId : descriptionId}
         aria-invalid={Boolean(error)}
         {...registration}
         className={clsx(

--- a/src/components/utils/index.ts
+++ b/src/components/utils/index.ts
@@ -1,1 +1,0 @@
-export * from "./transformLabel";

--- a/src/components/utils/transformLabel.ts
+++ b/src/components/utils/transformLabel.ts
@@ -1,3 +1,0 @@
-export const transformLabel = (label: string) => {
-  return label.toLowerCase().replace(/\s+/g, "_");
-};


### PR DESCRIPTION
## Change Description 
- Remove transformLabel utils function to connect labels with inputs.
- Using useId from React instead.
- Adding improvements to accessibility through `aria-describedby` and `aria-invalid`

## Type of Change 
- [ ] Bug Fix 
- [ ] New Feature 
- [X] Refactor 
- [ ] Documentation Improvement 
- [ ] Other (specify: _______) 

## Verification 
- [ ] The pull request depends on another pull request 
- [X] All existing tests pass after the changes. 
- [ ] New tests have been added to cover the changes (if applicable). 
- [ ] Documentation has been updated to reflect the changes (if applicable). 
- [ ] The feature works as expected and meets the acceptance criteria. 

