### PR TITLE
[280] Splitted ActivityTable and SortIcon in two components

### DIFF
--- a/src/components/core/Table/SortIcon.tsx
+++ b/src/components/core/Table/SortIcon.tsx
@@ -1,0 +1,31 @@
+import {
+  ChevronDownIcon,
+  ChevronUpDownIcon,
+  ChevronUpIcon,
+} from "@heroicons/react/24/outline";
+
+import { SortDirection } from "@tanstack/react-table";
+
+type Props = {
+  sortDirection: SortDirection | false;
+  canSort: boolean;
+};
+
+export const SortIcon = ({ sortDirection, canSort }: Props) => {
+  if (!canSort) return null;
+  if (sortDirection === false)
+    return <ChevronUpDownIcon aria-hidden className="size-5 text-gray-400" />;
+  if (sortDirection === "asc")
+    return (
+      <ChevronUpIcon
+        aria-hidden
+        className="m-1 size-3 stroke-2 text-gray-400"
+      />
+    );
+  return (
+    <ChevronDownIcon
+      aria-hidden
+      className="m-1 size-3 stroke-2 text-gray-400"
+    />
+  );
+};

--- a/src/features/activities/components/ActivityTable.tsx
+++ b/src/features/activities/components/ActivityTable.tsx
@@ -1,5 +1,4 @@
 import {
-  SortDirection,
   createColumnHelper,
   flexRender,
   getCoreRowModel,
@@ -10,36 +9,13 @@ import {
 import { useActivities } from "../api/tanstack/useActivities";
 import { useMemo } from "react";
 
-import {
-  ChevronDownIcon,
-  ChevronUpDownIcon,
-  ChevronUpIcon,
-} from "@heroicons/react/24/outline";
 import { ActivityAPI } from "../types/activityAPI";
 import { EmptyState } from "@/components/core/Table/EmptyState";
 import { Loading } from "@/components/core";
+import { SortIcon } from "@/components/core/Table/SortIcon";
 import { StateInputText } from "@/components/form";
 import { clsx } from "clsx";
 import { displayTableDuration } from "../utils/displayTableDuration";
-
-const displaySortIcon = (column: SortDirection | false, canSort: boolean) => {
-  if (!canSort) return null;
-  if (column === false)
-    return <ChevronUpDownIcon aria-hidden className="size-5 text-gray-400" />;
-  if (column === "asc")
-    return (
-      <ChevronUpIcon
-        aria-hidden
-        className="m-1 size-3 stroke-2 text-gray-400"
-      />
-    );
-  return (
-    <ChevronDownIcon
-      aria-hidden
-      className="m-1 size-3 stroke-2 text-gray-400"
-    />
-  );
-};
 
 const columnHelper = createColumnHelper<ActivityAPI>();
 
@@ -126,10 +102,10 @@ export const ActivityTable = () => {
                             header.getContext(),
                           )}
 
-                          {displaySortIcon(
-                            header.column.getIsSorted(),
-                            header.column.getCanSort(),
-                          )}
+                          <SortIcon
+                            sortDirection={header.column.getIsSorted()}
+                            canSort={header.column.getCanSort()}
+                          />
                         </div>
                       </th>
                     ))}


### PR DESCRIPTION
## Change Description 
- Split `SortIcon` and `ActivityTable`

## Type of Change 
- [ ] Bug Fix 
- [ ] New Feature 
- [x] Refactor 
- [ ] Documentation Improvement 
- [ ] Other (specify: _______) 

## Verification 
- [ ] The pull request depends on another pull request 
- [x] All existing tests pass after the changes. 
- [ ] New tests have been added to cover the changes (if applicable). 
- [ ] Documentation has been updated to reflect the changes (if applicable). 
- [x] The feature works as expected and meets the acceptance criteria. 
