### PR TITLE
Bump hookform/devtools to 4.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
-        "@hookform/devtools": "^4.3.1",
+        "@hookform/devtools": "^4.3.3",
         "@tailwindcss/forms": "^0.5.9",
         "@tanstack/eslint-plugin-query": "^5.62.1",
         "@testing-library/jest-dom": "^6.6.3",
@@ -1160,10 +1160,11 @@
       }
     },
     "node_modules/@hookform/devtools": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@hookform/devtools/-/devtools-4.3.1.tgz",
-      "integrity": "sha512-CrWxEoHQZaOXJZVQ8KBgOuAa8p2LI8M0DAN5GTRTmdCieRwFVjVDEmuTAVazWVRRkpEQSgSt3KYp7VmmqXdEnw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@hookform/devtools/-/devtools-4.3.3.tgz",
+      "integrity": "sha512-W9MipDe6P5y2XLos9coN4/fZhbt0YE2c+PaUx7tiKdc9XNQ2UOWCYTtysCnbj7fipZWEJht8J/UyQmXprWEhgw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.1.5",
         "@emotion/styled": "^11.3.0",
@@ -1175,8 +1176,8 @@
         "uuid": "^8.3.2"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18",
-        "react-dom": "^16.8.0 || ^17 || ^18"
+        "react": "^16.8.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
-    "@hookform/devtools": "^4.3.1",
+    "@hookform/devtools": "^4.3.3",
     "@tailwindcss/forms": "^0.5.9",
     "@tanstack/eslint-plugin-query": "^5.62.1",
     "@testing-library/jest-dom": "^6.6.3",


### PR DESCRIPTION
## Change Description
- Bumped React Hook Form devtools to version 4.3.3 (React 19 compatible)