### PR TITLE
[325] Moved ResizeObserver to test setup file

### DIFF
--- a/src/features/categories/components/CategoryForm.spec.tsx
+++ b/src/features/categories/components/CategoryForm.spec.tsx
@@ -3,14 +3,6 @@ import { CategoryForm } from "./CategoryForm";
 import userEvent from "@testing-library/user-event";
 
 describe("CategoryForm", () => {
-  const ResizeObserverMock = vi.fn(() => ({
-    observe: vi.fn(),
-    unobserve: vi.fn(),
-    disconnect: vi.fn(),
-  }));
-
-  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
-
   it("shows all 14 colors as options", async () => {
     const user = userEvent.setup();
     render(<CategoryForm onSubmit={vi.fn()} />);

--- a/src/features/tasks/components/TaskStatusSelectFilter.spec.tsx
+++ b/src/features/tasks/components/TaskStatusSelectFilter.spec.tsx
@@ -5,14 +5,6 @@ import { TaskStatusSelectFilter } from "./TaskStatusSelectFilter";
 import userEvent from "@testing-library/user-event";
 
 describe("TaskStatusSelectFilter", () => {
-  const ResizeObserverMock = vi.fn(() => ({
-    observe: vi.fn(),
-    unobserve: vi.fn(),
-    disconnect: vi.fn(),
-  }));
-
-  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
-
   it("renders with 'All' by default", () => {
     const Stub = createRoutesStub([
       {

--- a/src/pages/forms/UseController/ControllerTwo.spec.tsx
+++ b/src/pages/forms/UseController/ControllerTwo.spec.tsx
@@ -3,14 +3,6 @@ import { ControllerTwo } from "./ControllerTwo";
 import userEvent from "@testing-library/user-event";
 
 describe("ControllerTwo", () => {
-  const ResizeObserverMock = vi.fn(() => ({
-    observe: vi.fn(),
-    unobserve: vi.fn(),
-    disconnect: vi.fn(),
-  }));
-
-  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
-
   it("shows error messages when submit empty", async () => {
     const favFoodMessage = "I NEED to know your favorite food";
     const favPlanetMessage = "Are you annoyed that Uranus is not an option?";

--- a/src/pages/forms/controller/ControllerOne.spec.tsx
+++ b/src/pages/forms/controller/ControllerOne.spec.tsx
@@ -3,14 +3,6 @@ import { ControllerOne } from "./ControllerOne";
 import userEvent from "@testing-library/user-event";
 
 describe("ControllerOne", () => {
-  const ResizeObserverMock = vi.fn(() => ({
-    observe: vi.fn(),
-    unobserve: vi.fn(),
-    disconnect: vi.fn(),
-  }));
-
-  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
-
   it('focuses on the input when the "Focus" button is clicked', async () => {
     const user = userEvent.setup();
     render(<ControllerOne />);

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,11 +1,9 @@
 import "@testing-library/jest-dom";
 
-beforeAll(() => {
-  const ResizeObserverMock = vi.fn(() => ({
-    observe: vi.fn(),
-    unobserve: vi.fn(),
-    disconnect: vi.fn(),
-  }));
+const ResizeObserverMock = vi.fn(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
 
-  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
-});
+vi.stubGlobal("ResizeObserver", ResizeObserverMock);

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,11 @@
 import "@testing-library/jest-dom";
+
+beforeAll(() => {
+  const ResizeObserverMock = vi.fn(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  }));
+
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+});


### PR DESCRIPTION
## Change Description
- Moved `ResizeObserverMock` to our setup file so it runs before each test file.
- The benefit is not having to define `ResizeObserverMock` in each test file separately.

## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [x] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification

- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [x] The feature works as expected and meets the acceptance criteria.