### PR TITLE
[353] Fixing bug where Form is not reactive to API changes

### DIFF
--- a/src/features/activities/components/ActivityForm.tsx
+++ b/src/features/activities/components/ActivityForm.tsx
@@ -24,7 +24,7 @@ export const ActivityForm = ({
   submitButtonText,
 }: Props) => {
   const { control, formState, handleSubmit, register } = useForm<CreateForm>({
-    defaultValues: { ...defaultActivity, ...initialValues },
+    values: { ...defaultActivity, ...initialValues },
   });
   const { errors, isSubmitting } = formState;
 


### PR DESCRIPTION
## Change Description
- Changed `defaultValues` with `values` which do respond to API changes.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
