### PR TITLE
[362] Delete action no longer triggers edit dialog

### DIFF
--- a/src/features/tasks/components/DeleteTask.tsx
+++ b/src/features/tasks/components/DeleteTask.tsx
@@ -22,7 +22,10 @@ export const DeleteTask = ({ taskId }: Props) => {
         shape="circle"
         aria-label={BTN_TEXT}
         variant="dangerOutline"
-        onClick={onOpen}>
+        onClick={(e) => {
+          e.preventDefault();
+          onOpen();
+        }}>
         <TrashIcon className="size-5" aria-hidden />
       </IconButton>
 


### PR DESCRIPTION
## Change Description
- Button to delete task no longer propagates event to parent.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
