### PR TITLE
[439] Fixed timer freezing

### DIFF
--- a/src/pages/timer/TimerTime.tsx
+++ b/src/pages/timer/TimerTime.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { convertSecondsToHHMMSS } from "@/utils";
 
@@ -17,8 +17,8 @@ type Props = {
 };
 
 export const TimerTime = ({ start_time }: Props) => {
-  const elapsedSeconds = useMemo(() => elapsedTime(start_time), [start_time]);
-  const [time, setTime] = useState(elapsedSeconds);
+  const [, setTime] = useState(0);
+  const elapsedSeconds = elapsedTime(start_time);
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -27,5 +27,5 @@ export const TimerTime = ({ start_time }: Props) => {
     return () => clearInterval(id);
   }, []);
 
-  return <div>{convertSecondsToHHMMSS(time)}</div>;
+  return <div>{convertSecondsToHHMMSS(elapsedSeconds)}</div>;
 };


### PR DESCRIPTION
## Change Description
- Instead of storing my `start_time` in the useState and add 1 second every 1000 miliseconds, I now setTimer but re-calculate the time every time, meaning there is no way for the timer to get out of sync.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [x] The feature works as expected and meets the acceptance criteria.
