### PR TITLE
[511] Added end_time task filter

### DIFF
--- a/src/features/tasks/api/axios/getTasks.ts
+++ b/src/features/tasks/api/axios/getTasks.ts
@@ -7,7 +7,7 @@ export const getTasks = async ({
   signal,
   queryKey,
 }: QueryFunctionContext<ReturnType<(typeof taskKeys)["list"]>>) => {
-  const [{ status, category_id, created_at }] = queryKey;
+  const [{ status, category_id, created_at, end_time }] = queryKey;
 
   const { data } = await apiV1.get<TaskAPI[]>(TASKS_ENDPOINT, {
     signal,
@@ -15,6 +15,7 @@ export const getTasks = async ({
       status,
       category_id,
       created_at,
+      end_time,
       time_zone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     },
   });

--- a/src/features/tasks/api/queryKeys.ts
+++ b/src/features/tasks/api/queryKeys.ts
@@ -4,8 +4,15 @@ import { TaskStatus } from "../types/task-status";
 export const taskKeys = {
   all: [{ scope: TASKS_ENDPOINT }] as const,
   lists: () => [{ ...taskKeys.all[0], entity: "list" }] as const,
-  list: (status?: TaskStatus, category_id?: number, created_at?: string) =>
-    [{ ...taskKeys.lists()[0], status, category_id, created_at }] as const,
+  list: (
+    status?: TaskStatus,
+    category_id?: number,
+    created_at?: string,
+    end_time?: string,
+  ) =>
+    [
+      { ...taskKeys.lists()[0], status, category_id, created_at, end_time },
+    ] as const,
   details: () => [{ ...taskKeys.all[0], entity: "details" }] as const,
   detail: (taskId: number) => [{ ...taskKeys.details()[0], taskId }] as const,
 };

--- a/src/features/tasks/api/tanstack/useTasks.ts
+++ b/src/features/tasks/api/tanstack/useTasks.ts
@@ -6,9 +6,14 @@ import { taskKeys } from "../queryKeys";
 
 type Props = Partial<TaskApiFilters>;
 
-export const useTasks = ({ status, category_id, created_at }: Props = {}) => {
+export const useTasks = ({
+  status,
+  category_id,
+  created_at,
+  end_time,
+}: Props = {}) => {
   return useQuery({
-    queryKey: taskKeys.list(status, category_id, created_at),
+    queryKey: taskKeys.list(status, category_id, created_at, end_time),
     queryFn: getTasks,
   });
 };

--- a/src/features/tasks/types/taskApiFilters.ts
+++ b/src/features/tasks/types/taskApiFilters.ts
@@ -4,4 +4,5 @@ export type TaskApiFilters = {
   status: TaskStatus;
   category_id: number;
   created_at: string;
+  end_time: string;
 };

--- a/src/pages/Tasks/TodayCompletedTaskList.tsx
+++ b/src/pages/Tasks/TodayCompletedTaskList.tsx
@@ -11,7 +11,7 @@ import { TaskErrorList } from "@/features/tasks/components/TaskErrorList";
 export const TodayCompletedTaskList = () => {
   const { data, isPending, isError, refetch } = useTasks({
     status: "completed",
-    created_at: "today",
+    end_time: "today",
   });
 
   if (isPending)


### PR DESCRIPTION
## Change Description
- Add `end_time` as filter.
- Add `end_time` to queryKeys
- Update TodayCompletedTaskList from `created_at` to `end_time`.

## Related Tasks
[Backend Ticket](https://github.com/brandonrq506/first_api/pull/41)

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [x] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [x] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
