### PR TITLE
[548] Added ability to hide label

### DIFF
--- a/src/components/form/ComboBox/ComboBox.tsx
+++ b/src/components/form/ComboBox/ComboBox.tsx
@@ -53,6 +53,7 @@ export const ComboBox = ({
   ref,
   config,
   description,
+  hideLabel = false,
   label,
   options,
   showAsterisk = false,
@@ -73,7 +74,11 @@ export const ComboBox = ({
 
   return (
     <Field>
-      <Label className="block text-sm leading-6 font-medium text-gray-900">
+      <Label
+        className={clsx(
+          "block text-sm leading-6 font-medium text-gray-900",
+          hideLabel && "sr-only",
+        )}>
         {label} {showAsterisk && <span className="ml-1 text-red-700">*</span>}
       </Label>
       <Combobox
@@ -82,7 +87,7 @@ export const ComboBox = ({
         value={value}
         onChange={onChange}
         onClose={() => setQuery("")}>
-        <div className="relative mt-2">
+        <div className={clsx("relative", !hideLabel && "mt-2")}>
           <ComboboxInput
             className={clsx(
               "w-full rounded-md border-0 bg-white py-1.5 pr-10 pl-3 text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset focus:ring-2 focus:ring-indigo-600 focus:ring-inset sm:text-sm sm:leading-6",

--- a/src/components/form/ComboBox/ControlComboBox.tsx
+++ b/src/components/form/ComboBox/ControlComboBox.tsx
@@ -12,6 +12,7 @@ type ControlledComboBoxProps<T extends FieldValues> = UseControllerProps<T> &
 export const ControlComboBox = <T extends FieldValues>({
   config,
   description,
+  hideLabel,
   label,
   options,
   showAsterisk,
@@ -22,6 +23,7 @@ export const ControlComboBox = <T extends FieldValues>({
     <ComboBox
       config={config}
       description={description}
+      hideLabel={hideLabel}
       label={label}
       options={options}
       showAsterisk={showAsterisk}

--- a/src/components/form/ComboBox/types/index.ts
+++ b/src/components/form/ComboBox/types/index.ts
@@ -10,6 +10,7 @@ export type ComboBoxType = {
   options: Option[];
   label: string;
   config?: Configuration;
-  showAsterisk?: boolean;
   description?: string;
+  hideLabel?: boolean;
+  showAsterisk?: boolean;
 };

--- a/src/components/form/NumerInput/NumberInput.tsx
+++ b/src/components/form/NumerInput/NumberInput.tsx
@@ -1,42 +1,42 @@
-import { useId } from "react";
-
+import { Description, Field, Input, Label } from "@headlessui/react";
 import { ExclamationCircleIcon } from "@heroicons/react/20/solid";
 import { UseFormRegisterReturn } from "react-hook-form";
 import { clsx } from "clsx";
 
 type InputProps = {
   className?: string;
-  label: string;
-  showAsterisk?: boolean;
-  placeholder?: string;
-  registration?: Partial<UseFormRegisterReturn>;
   description?: string;
   error?: string;
+  hideLabel?: boolean;
+  label: string;
+  placeholder?: string;
+  registration?: Partial<UseFormRegisterReturn>;
+  showAsterisk?: boolean;
 };
 
 export const NumberInput = ({
   className,
-  label,
-  showAsterisk,
-  placeholder,
-  registration,
   description,
   error,
+  hideLabel = false,
+  label,
+  placeholder,
+  registration,
+  showAsterisk,
 }: InputProps) => {
-  const id = useId();
-  const descriptionId = `number-input-description-${id}`;
-  const errorId = `number-input-error-${id}`;
-
   return (
-    <div className={clsx(className)}>
-      <label className="block text-sm leading-6 font-medium text-gray-900">
+    <Field className={clsx(className)}>
+      <Label
+        className={clsx(
+          "block text-sm leading-6 font-medium text-gray-900",
+          hideLabel && "sr-only",
+        )}>
         <span>{label}</span>
         {showAsterisk && <span className="ml-1 text-red-700">*</span>}
-        <div className="relative mt-2">
-          <input
+        <div className={clsx("relative", !hideLabel && "mt-2")}>
+          <Input
             type="number"
             placeholder={placeholder}
-            aria-describedby={error ? errorId : descriptionId}
             aria-invalid={Boolean(error)}
             {...registration}
             className={clsx(
@@ -56,20 +56,19 @@ export const NumberInput = ({
             </div>
           )}
         </div>
-      </label>
+      </Label>
       {description && !error && (
-        <p id={descriptionId} className="mt-2 text-sm font-light text-gray-500">
+        <Description className="mt-2 text-sm font-light text-gray-500">
           {description}
-        </p>
+        </Description>
       )}
       {error && (
-        <p
-          id={errorId}
+        <Description
           role="alert"
           className="mt-2 text-sm font-light text-red-600">
           {error}
-        </p>
+        </Description>
       )}
-    </div>
+    </Field>
   );
 };

--- a/src/components/form/Select/Select.tsx
+++ b/src/components/form/Select/Select.tsx
@@ -26,6 +26,7 @@ type Props = SelectRHFProps & SelectType;
 export const Select = ({
   ref,
   description,
+  hideLabel = false,
   label,
   options,
   showAsterisk,
@@ -37,7 +38,11 @@ export const Select = ({
 }: Props) => {
   return (
     <Field className="w-full">
-      <Label className="block text-sm leading-6 font-medium text-gray-900">
+      <Label
+        className={clsx(
+          "block text-sm leading-6 font-medium text-gray-900",
+          hideLabel && "sr-only",
+        )}>
         {label} {showAsterisk && <span className="ml-1 text-red-700">*</span>}
       </Label>
 
@@ -48,7 +53,7 @@ export const Select = ({
         value={value}
         onBlur={onBlur}
         onChange={onChange}
-        className="mt-2">
+        className={clsx(!hideLabel && "mt-2")}>
         <ListboxButton
           ref={ref}
           data-invalid={error}

--- a/src/components/form/Select/StringSelect.tsx
+++ b/src/components/form/Select/StringSelect.tsx
@@ -27,6 +27,7 @@ export const StringSelect = ({
   ref,
   description,
   label,
+  hideLabel = false,
   options,
   showAsterisk,
   value,
@@ -37,7 +38,11 @@ export const StringSelect = ({
 }: Props) => {
   return (
     <Field className="w-full">
-      <Label className="block text-sm leading-6 font-medium text-gray-900">
+      <Label
+        className={clsx(
+          "block text-sm leading-6 font-medium text-gray-900",
+          hideLabel && "sr-only",
+        )}>
         {label} {showAsterisk && <span className="ml-1 text-red-700">*</span>}
       </Label>
 
@@ -48,7 +53,7 @@ export const StringSelect = ({
         value={value}
         onBlur={onBlur}
         onChange={onChange}
-        className="mt-2">
+        className={clsx(!hideLabel && "mt-2")}>
         <ListboxButton
           ref={ref}
           data-invalid={error}

--- a/src/components/form/Select/types/index.ts
+++ b/src/components/form/Select/types/index.ts
@@ -3,6 +3,7 @@ import { Option, StringOption } from "@/types/core";
 export type SelectType = {
   description?: string;
   label: string;
+  hideLabel?: boolean;
   options: Option[];
   showAsterisk?: boolean;
 };
@@ -10,6 +11,7 @@ export type SelectType = {
 export type StringSelectType = {
   description?: string;
   label: string;
+  hideLabel?: boolean;
   options: StringOption[];
   showAsterisk?: boolean;
 };

--- a/src/components/form/TextInput/TextInput.spec.tsx
+++ b/src/components/form/TextInput/TextInput.spec.tsx
@@ -7,6 +7,11 @@ describe("TextInput", () => {
     expect(screen.getByLabelText(/Name/i)).toBeInTheDocument();
   });
 
+  it("is accessible even if label is hidden", () => {
+    render(<TextInput label="Invisible" registration={{}} hideLabel />);
+    expect(screen.getByLabelText(/invisible/i)).toBeInTheDocument();
+  });
+
   it("displays the asterisk if showAsterisk is true", () => {
     render(<TextInput label="Password" showAsterisk registration={{}} />);
     expect(screen.getByText("*")).toBeInTheDocument();

--- a/src/components/form/TextInput/TextInput.tsx
+++ b/src/components/form/TextInput/TextInput.tsx
@@ -32,6 +32,7 @@ type Props = CustomTextField & {
   error?: string;
   inputClassName?: string;
   label: string;
+  hideLabel?: boolean;
   registration: Partial<UseFormRegisterReturn>;
   showAsterisk?: boolean;
   type?: Types;
@@ -43,6 +44,7 @@ export const TextInput = ({
   error,
   inputClassName,
   label,
+  hideLabel = false,
   registration,
   showAsterisk = false,
   type = "text",
@@ -50,7 +52,11 @@ export const TextInput = ({
 }: Props) => {
   return (
     <Field className={clsx(className)}>
-      <Label className="block text-sm leading-6 font-medium text-gray-900">
+      <Label
+        className={clsx(
+          "block text-sm leading-6 font-medium text-gray-900",
+          hideLabel && "sr-only",
+        )}>
         {label} {showAsterisk && <span className="ml-1 text-red-700">*</span>}
       </Label>
       <Input
@@ -61,10 +67,11 @@ export const TextInput = ({
         {...registration}
         {...props}
         className={clsx(
-          "mt-2 block w-full rounded-md border-0 py-1.5 text-sm font-light text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset placeholder:text-gray-400 sm:leading-6",
+          "block w-full rounded-md border-0 py-1.5 text-sm font-light text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset placeholder:text-gray-400 sm:leading-6",
           "data-focus:ring-2 data-focus:ring-indigo-600 data-focus:ring-inset",
           "data-disabled:cursor-not-allowed data-disabled:bg-gray-50 data-disabled:text-gray-500 data-disabled:ring-gray-200",
           "data-invalid:text-red-900 data-invalid:ring-red-300 data-invalid:placeholder:text-red-300 data-invalid:focus:ring-red-500",
+          !hideLabel && "mt-2",
           inputClassName,
         )}
       />

--- a/src/components/form/TimeInput/TimeInput.tsx
+++ b/src/components/form/TimeInput/TimeInput.tsx
@@ -27,6 +27,7 @@ type Props = CustomTimeField & {
   error?: string;
   inputClassName?: string;
   label: string;
+  hideLabel?: boolean;
   registration: Partial<UseFormRegisterReturn>;
   showAsterisk?: boolean;
 };
@@ -37,13 +38,14 @@ export const TimeInput = ({
   error,
   inputClassName,
   label,
+  hideLabel = false,
   registration,
   showAsterisk = false,
   ...props
 }: Props) => {
   return (
     <Field className={clsx(className)}>
-      <Label>
+      <Label className={clsx(hideLabel && "sr-only")}>
         {label} {showAsterisk && <span className="ml-1 text-red-700">*</span>}
       </Label>
       <Input
@@ -53,10 +55,11 @@ export const TimeInput = ({
         {...registration}
         {...props}
         className={clsx(
-          "mt-2 block w-full rounded-md border-0 py-1.5 text-sm font-light text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset placeholder:text-gray-400 sm:leading-6",
+          "block w-full rounded-md border-0 py-1.5 text-sm font-light text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset placeholder:text-gray-400 sm:leading-6",
           "data-focus:ring-2 data-focus:ring-indigo-600 data-focus:ring-inset",
           "data-disabled:cursor-not-allowed data-disabled:bg-gray-50 data-disabled:text-gray-500 data-disabled:ring-gray-200",
           "data-invalid:text-red-900 data-invalid:ring-red-300 data-invalid:placeholder:text-red-300 data-invalid:focus:ring-red-500",
+          !hideLabel && "mt-2",
           inputClassName,
         )}
       />

--- a/src/components/form/TimeInput/TimeInputV2.tsx
+++ b/src/components/form/TimeInput/TimeInputV2.tsx
@@ -31,6 +31,7 @@ type CustomTimeProps = CustomTimeField & {
   description?: string;
   inputClassName?: string;
   label: string;
+  hideLabel?: boolean;
   showAsterisk?: boolean;
 };
 
@@ -49,6 +50,7 @@ export const TimeInputV2 = <T extends FieldValues>({
   description,
   inputClassName,
   label,
+  hideLabel = false,
   showAsterisk = false,
   ...props
 }: ControlledTimeInputProps<T>) => {
@@ -73,7 +75,11 @@ export const TimeInputV2 = <T extends FieldValues>({
 
   return (
     <Field className={clsx(className)}>
-      <Label className="block text-sm leading-6 font-medium text-gray-900">
+      <Label
+        className={clsx(
+          "block text-sm leading-6 font-medium text-gray-900",
+          hideLabel && "sr-only",
+        )}>
         {label} {showAsterisk && <span className="ml-1 text-red-700">*</span>}
       </Label>
       <Input
@@ -90,10 +96,11 @@ export const TimeInputV2 = <T extends FieldValues>({
         invalid={Boolean(error)}
         {...props}
         className={clsx(
-          "mt-2 block w-full rounded-md border-0 py-1.5 text-sm font-light text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset placeholder:text-gray-400 sm:leading-6",
+          "block w-full rounded-md border-0 py-1.5 text-sm font-light text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset placeholder:text-gray-400 sm:leading-6",
           "data-focus:ring-2 data-focus:ring-indigo-600 data-focus:ring-inset",
           "data-disabled:cursor-not-allowed data-disabled:bg-gray-50 data-disabled:text-gray-500 data-disabled:ring-gray-200",
           "data-invalid:text-red-900 data-invalid:ring-red-300 data-invalid:placeholder:text-red-300 data-invalid:focus:ring-red-500",
+          !hideLabel && "mt-2",
           inputClassName,
         )}
       />

--- a/src/features/activities/components/ActivityComboBox.tsx
+++ b/src/features/activities/components/ActivityComboBox.tsx
@@ -1,20 +1,29 @@
 import { useActivities } from "../api/tanstack/useActivities";
 
 import { FieldValues, UseControllerProps } from "react-hook-form";
+import { ComboBoxType } from "@/components/form/ComboBox/types";
 import { ControlComboBox } from "@/components/form";
 import { transformToOption } from "@/utils";
 
+type ActivityComboBoxProps = Omit<ComboBoxType, "options" | "label">;
+
 export const ActivityComboBox = <T extends FieldValues>({
+  description,
+  hideLabel,
+  showAsterisk,
   ...controllerProps
-}: UseControllerProps<T>) => {
+}: UseControllerProps<T> & ActivityComboBoxProps) => {
   const { data } = useActivities();
 
   const options = data?.map((c) => transformToOption(c, "id", "name")) ?? [];
 
   return (
     <ControlComboBox
+      description={description}
+      hideLabel={hideLabel}
       label="Activities"
       options={options}
+      showAsterisk={showAsterisk}
       {...controllerProps}
     />
   );

--- a/src/features/tasks/components/TaskForm.tsx
+++ b/src/features/tasks/components/TaskForm.tsx
@@ -29,9 +29,11 @@ export const TaskForm = ({ initialValues, task, onSubmit }: Props) => {
   const isInProgressTask = task.status === "in_progress";
 
   return (
-    <form onSubmit={handleSubmit((data) => onSubmit(data))}>
-      <div className="flex items-start justify-between">
-        <ActivityComboBox control={control} name="activity" />
+    <form
+      onSubmit={handleSubmit((data) => onSubmit(data))}
+      className="flex flex-col gap-y-2">
+      <div className="flex items-center justify-between">
+        <ActivityComboBox control={control} name="activity" hideLabel />
         <CategoryBadge category={task.activity.category} />
       </div>
 
@@ -73,7 +75,7 @@ export const TaskForm = ({ initialValues, task, onSubmit }: Props) => {
         />
       )}
 
-      <div className="mt-2 flex justify-center">
+      <div className="flex justify-center">
         <Button type="submit" disabled={isSubmitting}>
           {`${UPDATE} ${TASK}`}
         </Button>

--- a/src/pages/timer/IdleTimer.tsx
+++ b/src/pages/timer/IdleTimer.tsx
@@ -31,6 +31,7 @@ export const IdleTimer = () => {
     <form onSubmit={handleSubmit(onSubmit)} className="flex items-center gap-2">
       <div className="w-full">
         <ActivityComboBox
+          hideLabel
           control={control}
           name="activity_id"
           rules={{


### PR DESCRIPTION
## Change Description
- All Inputs now have the option to `hideLabel` (off by default)
- When Lable is off, the `mt-2` between input and label also disappears.
- Added a new test
- Hid label from `ActivityComboBox` because it looks amazing!

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor
- [x] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [x] New tests have been added to cover the changes (if applicable).
- [x] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
