### PR TITLE
[548] Split DateFilter into DateInput and DateFilter

### DIFF
--- a/src/components/core/Date/DateFilter.spec.tsx
+++ b/src/components/core/Date/DateFilter.spec.tsx
@@ -1,84 +1,43 @@
 import { render, screen } from "@testing-library/react";
-import { DateFilter } from "./DateFilter";
-import { createRoutesStub } from "react-router";
-import userEvent from "@testing-library/user-event";
+import { DateInput } from "./DateInput";
 
-describe("DateFilter", () => {
+describe("DateInput", () => {
   it("renders the label and input correctly", () => {
-    const Stub = createRoutesStub([
-      { path: "/", Component: () => <DateFilter label="Date" /> },
-    ]);
-    render(<Stub initialEntries={["/"]} />);
+    render(<DateInput label="Date" />);
 
     expect(screen.getByLabelText(/Date/i)).toBeInTheDocument();
   });
 
   it("displays the asterisk if showAsterisk is true", () => {
-    const Stub = createRoutesStub([
-      { path: "/", Component: () => <DateFilter label="Date" showAsterisk /> },
-    ]);
-    render(<Stub initialEntries={["/"]} />);
+    render(<DateInput label="Date" showAsterisk />);
 
     expect(screen.getByText("*")).toBeInTheDocument();
   });
 
   it("does not display the asterisk if showAsterisk is false", () => {
-    const Stub = createRoutesStub([
-      { path: "/", Component: () => <DateFilter label="Date" /> },
-    ]);
-    render(<Stub initialEntries={["/"]} />);
+    render(<DateInput label="Date" />);
 
     expect(screen.queryByText("*")).not.toBeInTheDocument();
   });
 
   it("renders a description if provided", () => {
-    const Stub = createRoutesStub([
-      {
-        path: "/",
-        Component: () => (
-          <DateFilter label="Date" description="Select a date" />
-        ),
-      },
-    ]);
-    render(<Stub initialEntries={["/"]} />);
+    render(<DateInput label="Date" description="Select a date" />);
+
     expect(screen.getByText(/Select a date/i)).toBeInTheDocument();
   });
 
   it("hides the label if hideLabel is true", () => {
-    const Stub = createRoutesStub([
-      { path: "/", Component: () => <DateFilter label="Date" hideLabel /> },
-    ]);
-    render(<Stub initialEntries={["/"]} />);
+    render(<DateInput label="Date" hideLabel />);
 
     expect(screen.getByText(/Date/i)).toHaveClass("sr-only");
   });
 
   it("renders the input with the correct value", () => {
-    const Stub = createRoutesStub([
-      { path: "/", Component: () => <DateFilter label="Date" /> },
-    ]);
-    render(<Stub initialEntries={["/"]} />);
+    const value = "2021-01-01";
+    render(<DateInput label="Date" value={value} onChange={() => {}} />);
 
     const input = screen.getByLabelText(/Date/i) as HTMLInputElement;
 
-    const now = new Date();
-    now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
-    const today = now.toISOString().split("T")[0];
-
-    expect(input.value).toBe(today);
-  });
-
-  it("updates search params when input value changes", async () => {
-    const Stub = createRoutesStub([
-      { path: "/", Component: () => <DateFilter label="Date" /> },
-    ]);
-    render(<Stub initialEntries={["/"]} />);
-    const input = screen.getByLabelText(/Date/i) as HTMLInputElement;
-
-    const newDate = "2025-01-01";
-    await userEvent.clear(input);
-    await userEvent.type(input, newDate);
-
-    expect(input.value).toBe(newDate);
+    expect(input.value).toBe(value);
   });
 });

--- a/src/components/core/Date/DateFilter.tsx
+++ b/src/components/core/Date/DateFilter.tsx
@@ -1,19 +1,13 @@
 import { useSearchParams } from "react-router";
 
-import {
-  Description,
-  Field,
-  Input,
-  InputProps,
-  Label,
-} from "@headlessui/react";
-import clsx from "clsx";
+import { DateInput } from "./DateInput";
+import { InputProps } from "@headlessui/react";
 
 const now = new Date();
 now.setMinutes(now.getMinutes() - now.getTimezoneOffset());
 const today = now.toISOString().split("T")[0];
 
-type DateField = Omit<InputProps, "onChange" | "value" | "max">;
+type DateField = Omit<InputProps, "onChange" | "value" | "max" | "type">;
 
 type Props = DateField & {
   className?: string;
@@ -24,12 +18,6 @@ type Props = DateField & {
   label: string;
 };
 
-/*
-To Do: This could be broken down into a DateInput component and a DateFilter component
-The DateInput uses InputProps without Omit
-The DateFilter Omits those that it will use like value and onChange.
-Then we could have DateInput for RHF that omits onChange, onBlur, name, etc.
-*/
 export const DateFilter = ({
   className,
   description,
@@ -45,32 +33,16 @@ export const DateFilter = ({
   const date = params.get("date") ?? today;
 
   return (
-    <Field className={className}>
-      <Label
-        className={clsx(
-          "block text-sm leading-6 font-medium text-gray-900",
-          hideLabel && "sr-only",
-        )}>
-        {label} {showAsterisk && <span className="ml-1 text-red-700">*</span>}
-      </Label>
-      <Input
-        type="date"
-        value={date}
-        onChange={(e) => setParams({ date: e.target.value })}
-        max={today}
-        className={clsx(
-          "mt-2 block w-full rounded-md border-0 py-1.5 text-sm font-light text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset placeholder:text-gray-400 sm:leading-6",
-          "data-focus:ring-2 data-focus:ring-indigo-600 data-focus:ring-inset",
-          "data-disabled:cursor-not-allowed data-disabled:bg-gray-50 data-disabled:text-gray-500 data-disabled:ring-gray-200",
-          "data-invalid:text-red-900 data-invalid:ring-red-300 data-invalid:placeholder:text-red-300 data-invalid:focus:ring-red-500",
-          inputClassName,
-        )}
-      />
-      {description && (
-        <Description className="mt-2 text-sm font-light text-gray-500">
-          {description}
-        </Description>
-      )}
-    </Field>
+    <DateInput
+      className={className}
+      description={description}
+      hideLabel={hideLabel}
+      inputClassName={inputClassName}
+      label={label}
+      max={today}
+      onChange={(e) => setParams({ date: e.target.value })}
+      showAsterisk={showAsterisk}
+      value={date}
+    />
   );
 };

--- a/src/components/core/Date/DateInput.tsx
+++ b/src/components/core/Date/DateInput.tsx
@@ -1,0 +1,58 @@
+import {
+  Description,
+  Field,
+  Input,
+  InputProps,
+  Label,
+} from "@headlessui/react";
+import clsx from "clsx";
+
+type CustomProps = {
+  className?: string;
+  description?: string;
+  hideLabel?: boolean;
+  label: string;
+  showAsterisk?: boolean;
+  inputClassName?: string;
+};
+
+type Props = CustomProps & Omit<InputProps, "type">;
+
+export const DateInput = ({
+  className,
+  description,
+  hideLabel,
+  inputClassName,
+  label,
+  showAsterisk,
+  ...inputProps
+}: Props) => {
+  return (
+    <Field className={className}>
+      <Label
+        className={clsx(
+          "block text-sm leading-6 font-medium text-gray-900",
+          hideLabel && "sr-only",
+        )}>
+        {label} {showAsterisk && <span className="ml-1 text-red-700">*</span>}
+      </Label>
+      <Input
+        type="date"
+        className={clsx(
+          "block w-full rounded-md border-0 py-1.5 text-sm font-light text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset placeholder:text-gray-400 sm:leading-6",
+          "data-focus:ring-2 data-focus:ring-indigo-600 data-focus:ring-inset",
+          "data-disabled:cursor-not-allowed data-disabled:bg-gray-50 data-disabled:text-gray-500 data-disabled:ring-gray-200",
+          "data-invalid:text-red-900 data-invalid:ring-red-300 data-invalid:placeholder:text-red-300 data-invalid:focus:ring-red-500",
+          !hideLabel && "mt-2",
+          inputClassName,
+        )}
+        {...inputProps}
+      />
+      {description && (
+        <Description className="mt-2 text-sm font-light text-gray-500">
+          {description}
+        </Description>
+      )}
+    </Field>
+  );
+};


### PR DESCRIPTION
## Change Description
- Splitted `DateFilter` and now we have `DateInput`

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [x] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
