### PR TITLE
[552] Dialog closes immediately now

### DIFF
--- a/src/features/tasks/components/EditTaskForm.tsx
+++ b/src/features/tasks/components/EditTaskForm.tsx
@@ -12,10 +12,10 @@ type Props = {
 
 export const EditTaskForm = ({ task }: Props) => {
   const navigate = useNavigate();
-  const { mutateAsync } = useUpdateTask();
+  const { mutate } = useUpdateTask();
 
-  const handleSubmit = async (data: EditForm) => {
-    await mutateAsync({
+  const handleSubmit = (data: EditForm) => {
+    mutate({
       taskId: task.id,
       task: {
         activity_id: data.activity.value,


### PR DESCRIPTION
## Change Description
- Now that Editing a Task is done optimistically, there is no reason to display the dialog until the request is actually done. For the App to feel snappier the data and the UI should update immediately.

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
