### PR TITLE
[611] Added start_time as possible filter and update to that

### DIFF
--- a/src/features/tasks/types/taskApiFilters.ts
+++ b/src/features/tasks/types/taskApiFilters.ts
@@ -5,4 +5,5 @@ export type TaskApiFilters = {
   category_id: number;
   created_at: string;
   end_time: string;
+  start_time: string;
 };

--- a/src/pages/Tasks/FilterableTaskList.tsx
+++ b/src/pages/Tasks/FilterableTaskList.tsx
@@ -10,7 +10,7 @@ export const FilterableTaskList = () => {
   const dateParam = params.get("date") ?? "today";
 
   const { data, isPending, isError, refetch } = useTasks({
-    filter: { status: "completed", end_time: dateParam },
+    filter: { status: "completed", start_time: dateParam },
     sort: { sort_by: "start_time", sort_order: "asc" },
   });
 

--- a/src/pages/Tasks/TodayCompletedTaskList.tsx
+++ b/src/pages/Tasks/TodayCompletedTaskList.tsx
@@ -10,7 +10,7 @@ import { TaskErrorList } from "@/features/tasks/components/TaskErrorList";
 
 export const TodayCompletedTaskList = () => {
   const { data, isPending, isError, refetch } = useTasks({
-    filter: { status: "completed", end_time: "today" },
+    filter: { status: "completed", start_time: "today" },
     sort: { sort_by: "start_time", sort_order: "desc" },
   });
 


### PR DESCRIPTION
## Change Description
- Added `start_time` to filter type.
- Updated to `start_time` in TodayCompledTasks and FilterableTaskList component

## Related Tasks
[BE Ticket](https://github.com/brandonrq506/first_api/pull/50)

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
