### PR TITLE
[613] Fix Rare Crash

### DIFF
--- a/src/pages/timer/TimerTime.tsx
+++ b/src/pages/timer/TimerTime.tsx
@@ -20,17 +20,6 @@ export const TimerTime = ({ start_time }: Props) => {
   const [, setTime] = useState(0);
   const elapsedSeconds = elapsedTime(start_time);
 
-  let formattedTime;
-  try {
-    formattedTime = convertSecondsToHHMMSS(elapsedSeconds);
-  } catch (error) {
-    throw new Error(`
-      ElapsedSeconds: ${elapsedSeconds}\n
-      StartTime: ${start_time}\n
-      Now: ${new Date()}\n
-      Error: ${error}`);
-  }
-
   useEffect(() => {
     const id = setInterval(() => {
       setTime((c) => c + 1);
@@ -38,5 +27,5 @@ export const TimerTime = ({ start_time }: Props) => {
     return () => clearInterval(id);
   }, []);
 
-  return <div>{formattedTime}</div>;
+  return <div>{convertSecondsToHHMMSS(elapsedSeconds)}</div>;
 };

--- a/src/pages/timer/TimerTime.tsx
+++ b/src/pages/timer/TimerTime.tsx
@@ -8,8 +8,8 @@ const MILI_TO_SEC = 1000;
 const elapsedTime = (start_time: string) => {
   const start = new Date(start_time);
   const now = new Date();
-  const elapsed = now.getTime() - start.getTime();
-  return elapsed / MILI_TO_SEC;
+  const elapsed = (now.getTime() - start.getTime()) / MILI_TO_SEC;
+  return Math.max(0, elapsed);
 };
 
 type Props = {

--- a/src/utils/convertSecondsToHHMMSS.ts
+++ b/src/utils/convertSecondsToHHMMSS.ts
@@ -7,8 +7,7 @@ const padNumber = (number: number) => {
 };
 
 export const convertSecondsToHHMMSS = (seconds: number) => {
-  if (seconds < 0)
-    throw new Error(`Seconds must be a positive number. Provided: ${seconds}`);
+  if (seconds < 0) throw new Error("Seconds must be a positive number");
 
   const hours = Math.floor(seconds / SECONDS_IN_HOUR);
   const minutes = Math.floor((seconds % SECONDS_IN_HOUR) / SECONDS_IN_MINUTE);

--- a/src/utils/convertSecondsToHHMMSS.ts
+++ b/src/utils/convertSecondsToHHMMSS.ts
@@ -7,7 +7,8 @@ const padNumber = (number: number) => {
 };
 
 export const convertSecondsToHHMMSS = (seconds: number) => {
-  if (seconds < 0) throw new Error(`Seconds must be a positive number. Received: ${seconds}`);
+  if (seconds < 0)
+    throw new Error(`Seconds must be a positive number. Received: ${seconds}`);
 
   const hours = Math.floor(seconds / SECONDS_IN_HOUR);
   const minutes = Math.floor((seconds % SECONDS_IN_HOUR) / SECONDS_IN_MINUTE);

--- a/src/utils/convertSecondsToHHMMSS.ts
+++ b/src/utils/convertSecondsToHHMMSS.ts
@@ -7,7 +7,7 @@ const padNumber = (number: number) => {
 };
 
 export const convertSecondsToHHMMSS = (seconds: number) => {
-  if (seconds < 0) throw new Error("Seconds must be a positive number");
+  if (seconds < 0) throw new Error(`Seconds must be a positive number. Received: ${seconds}`);
 
   const hours = Math.floor(seconds / SECONDS_IN_HOUR);
   const minutes = Math.floor((seconds % SECONDS_IN_HOUR) / SECONDS_IN_MINUTE);


### PR DESCRIPTION
## Change Description
- Bug explanation: API and FE clocks seem not to be in sync, that results in Backend `start_time` to be somehow ahead of FE `const now = new Date` causing at least twice a day a weird situation in which the function `elapsedTime` returns -0.014 or -0.011 milliseconds. Since that's a negative value, it throws when doing the `throw if elapsedTime < 0`.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
