### PR TITLE
[569] Fixed button in button console error

### DIFF
--- a/src/features/tasks/components/QuickCreateTaskMenu.tsx
+++ b/src/features/tasks/components/QuickCreateTaskMenu.tsx
@@ -1,7 +1,7 @@
 import { useActivities } from "@/features/activities/api/tanstack/useActivities";
 import { useCreateTask } from "../api/tanstack/useCreateTask";
 
-import { FloatingMenu, IconButton, Loading } from "@/components/core";
+import { FloatingMenu, Loading } from "@/components/core";
 import { CategoryBadge } from "@/features/categories/components";
 import { MenuItem } from "@headlessui/react";
 import { PlusIcon } from "@heroicons/react/24/solid";
@@ -17,11 +17,7 @@ export const QuickCreateTaskMenu = () => {
     return (
       <FloatingMenu
         srBtnText={`${ADD} ${TASKS}`}
-        iconBtn={
-          <IconButton shape="circle">
-            <Loading sizeStyles="size-5" />
-          </IconButton>
-        }>
+        iconBtn={<Loading sizeStyles="size-5" />}>
         <MenuItem>
           <div className="py-10">
             <Loading />


### PR DESCRIPTION
## Change Description
- Removed `IconButton` which was being passed to another button, thus causing `button inside button` warning.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
