### PR TITLE
[606] Activity show activity name on delete

### DIFF
--- a/src/features/activities/components/ActivityActionMenu.spec.tsx
+++ b/src/features/activities/components/ActivityActionMenu.spec.tsx
@@ -1,18 +1,22 @@
 import { render, screen } from "@/test/test-utils";
-import { ActivityActionMenu } from "./ActivityActionMenu";
 import { createRoutesStub } from "react-router";
 import userEvent from "@testing-library/user-event";
 
+import { ActivityActionMenu } from "./ActivityActionMenu";
+import { activities } from "@/test/store/activities";
+
 describe("ActivityActionMenu", () => {
+  const activity = activities[0];
+
   it("redirects to edit page when clicking on update", async () => {
     const user = userEvent.setup();
     const Stub = createRoutesStub([
       {
         path: "/activities",
-        Component: () => <ActivityActionMenu activityId={1} />,
+        Component: () => <ActivityActionMenu activity={activity} />,
       },
       {
-        path: "/activities/edit/1",
+        path: `/activities/edit/${activity.id}`,
         Component: () => <div>edit page</div>,
       },
     ]);
@@ -29,7 +33,7 @@ describe("ActivityActionMenu", () => {
     const Stub = createRoutesStub([
       {
         path: "/activities",
-        Component: () => <ActivityActionMenu activityId={1} />,
+        Component: () => <ActivityActionMenu activity={activity} />,
       },
     ]);
     render(<Stub initialEntries={["/activities"]} />);

--- a/src/features/activities/components/ActivityActionMenu.tsx
+++ b/src/features/activities/components/ActivityActionMenu.tsx
@@ -7,14 +7,15 @@ import { ThreeDotsMenu } from "@/components/core";
 
 import { DELETE, UPDATE } from "@/constants/actions";
 import { ACTIVITY } from "@/constants/entities";
+import { ActivityAPI } from "../types/activityAPI";
 import { DeleteActivityDialog } from "./DeleteActivityDialog";
 import { Link } from "react-router";
 
 type Props = {
-  activityId: number;
+  activity: ActivityAPI;
 };
 
-export const ActivityActionMenu = ({ activityId }: Props) => {
+export const ActivityActionMenu = ({ activity }: Props) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
@@ -23,7 +24,7 @@ export const ActivityActionMenu = ({ activityId }: Props) => {
         <div className="py-1">
           <MenuItem>
             <Link
-              to={`/activities/edit/${activityId}`}
+              to={`/activities/edit/${activity.id}`}
               className="group flex w-full items-center gap-2 px-4 py-2 text-sm text-nowrap text-blue-600 data-focus:bg-gray-100 data-focus:text-gray-900 data-focus:outline-hidden">
               <PencilIcon aria-hidden className="size-4" />
               {UPDATE} {ACTIVITY}
@@ -45,7 +46,7 @@ export const ActivityActionMenu = ({ activityId }: Props) => {
       <DeleteActivityDialog
         isOpen={isOpen}
         onClose={onClose}
-        activityId={activityId}
+        activity={activity}
       />
     </Fragment>
   );

--- a/src/features/activities/components/ActivityTable.tsx
+++ b/src/features/activities/components/ActivityTable.tsx
@@ -51,7 +51,7 @@ export const ActivityTable = () => {
         id: "actions",
         cell: (props) => (
           <div className="flex items-center justify-center">
-            <ActivityActionMenu activityId={props.row.original.id} />
+            <ActivityActionMenu activity={props.row.original} />
           </div>
         ),
       }),

--- a/src/features/activities/components/DeleteActivity.spec.tsx
+++ b/src/features/activities/components/DeleteActivity.spec.tsx
@@ -28,4 +28,15 @@ describe("DeleteActivity", () => {
     expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
+
+  it("shows the name of the activity to be deleted", async () => {
+    const user = userEvent.setup();
+    render(<DeleteActivity activity={activity} />);
+
+    await user.click(screen.getByRole("button", { name: "Delete Activity" }));
+
+    expect(
+      screen.getByText(`Are you sure you want to delete "${activity.name}"?`),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/features/activities/components/DeleteActivity.spec.tsx
+++ b/src/features/activities/components/DeleteActivity.spec.tsx
@@ -1,10 +1,14 @@
 import { render, screen } from "@/test/test-utils";
-import { DeleteActivity } from "./DeleteActivity";
 import userEvent from "@testing-library/user-event";
 
+import { DeleteActivity } from "./DeleteActivity";
+import { activities } from "@/test/store/activities";
+
 describe("DeleteActivity", () => {
+  const activity = activities[0];
+
   it("shows delete icon button", () => {
-    render(<DeleteActivity activityId={1} />);
+    render(<DeleteActivity activity={activity} />);
 
     expect(
       screen.getByRole("button", { name: "Delete Activity" }),
@@ -13,7 +17,7 @@ describe("DeleteActivity", () => {
 
   it("shows delete activity dialog when delete icon button is clicked", async () => {
     const user = userEvent.setup();
-    render(<DeleteActivity activityId={1} />);
+    render(<DeleteActivity activity={activity} />);
 
     await user.click(screen.getByRole("button", { name: "Delete Activity" }));
 

--- a/src/features/activities/components/DeleteActivity.tsx
+++ b/src/features/activities/components/DeleteActivity.tsx
@@ -1,5 +1,6 @@
 import { useDisclosure } from "@/hooks";
 
+import { ActivityAPI } from "../types/activityAPI";
 import { DeleteActivityDialog } from "./DeleteActivityDialog";
 import { IconButton } from "@/components/core";
 import { TrashIcon } from "@heroicons/react/24/outline";
@@ -8,12 +9,12 @@ import { ACTIVITY } from "@/constants/entities";
 import { DELETE } from "@/constants/actions";
 
 type Props = {
-  activityId: number;
+  activity: ActivityAPI;
 };
 
 const BTN_TEXT = `${DELETE} ${ACTIVITY}`;
 
-export const DeleteActivity = ({ activityId }: Props) => {
+export const DeleteActivity = ({ activity }: Props) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
@@ -29,7 +30,7 @@ export const DeleteActivity = ({ activityId }: Props) => {
       <DeleteActivityDialog
         isOpen={isOpen}
         onClose={onClose}
-        activityId={activityId}
+        activity={activity}
       />
     </>
   );

--- a/src/features/activities/components/DeleteActivityDialog.tsx
+++ b/src/features/activities/components/DeleteActivityDialog.tsx
@@ -3,22 +3,19 @@ import { useDeleteActivity } from "../api/tanstack/useDeleteActivity";
 import { Button, ConfirmationModal } from "@/components/core";
 import { CANCEL, CONFIRM, DELETE } from "@/constants/actions";
 import { ACTIVITY } from "@/constants/entities";
+import { ActivityAPI } from "../types/activityAPI";
 
 type Props = {
   isOpen: boolean;
   onClose: () => void;
-  activityId: number;
+  activity: ActivityAPI;
 };
 
-export const DeleteActivityDialog = ({
-  isOpen,
-  onClose,
-  activityId,
-}: Props) => {
+export const DeleteActivityDialog = ({ isOpen, onClose, activity }: Props) => {
   const { mutate, isPending } = useDeleteActivity();
 
   const handleDelete = () => {
-    mutate(activityId, {
+    mutate(activity.id, {
       onSuccess: () => onClose(),
     });
   };
@@ -29,7 +26,7 @@ export const DeleteActivityDialog = ({
       onClose={onClose}
       icon="danger"
       title={`${DELETE} ${ACTIVITY}`}
-      description="Are you sure you want to delete this activity?"
+      description={`Are you sure you want to delete "${activity.name}"?`}
       actions={
         <>
           <Button

--- a/src/pages/TanstackTable/experiments/FirstAttempt.tsx
+++ b/src/pages/TanstackTable/experiments/FirstAttempt.tsx
@@ -50,7 +50,7 @@ export const FirstTableAttempt = () => {
       columnHelper.display({
         id: "actions",
         header: "Actions",
-        cell: (props) => <DeleteActivity activityId={props.row.original.id} />,
+        cell: (props) => <DeleteActivity activity={props.row.original} />,
       }),
       columnHelper.display({
         id: "edit",

--- a/src/pages/TanstackTable/experiments/GlobalSearchTable.tsx
+++ b/src/pages/TanstackTable/experiments/GlobalSearchTable.tsx
@@ -43,7 +43,7 @@ export const GlobalSearchTable = () => {
       columnHelper.display({
         id: "actions",
         header: "Actions",
-        cell: (props) => <DeleteActivity activityId={props.row.original.id} />,
+        cell: (props) => <DeleteActivity activity={props.row.original} />,
       }),
       columnHelper.display({
         id: "edit",
@@ -77,7 +77,7 @@ export const GlobalSearchTable = () => {
         value={table.getState().globalFilter}
         onChange={(e) => table.setGlobalFilter(String(e.target.value))}
         placeholder="Search..."
-        className="block w-1/3 rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6"
+        className="block w-1/3 rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6"
       />
       <br />
       <table className="w-full border text-center">

--- a/src/pages/TanstackTable/experiments/SortableTable.tsx
+++ b/src/pages/TanstackTable/experiments/SortableTable.tsx
@@ -61,7 +61,7 @@ export const SortableTable = () => {
       columnHelper.display({
         id: "actions",
         header: "Actions",
-        cell: (props) => <DeleteActivity activityId={props.row.original.id} />,
+        cell: (props) => <DeleteActivity activity={props.row.original} />,
       }),
       columnHelper.display({
         id: "edit",


### PR DESCRIPTION
## Change Description
- Instead of passing just `ActivityId` we now pass the whole object, proving name and other information in case we need it in the future.

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
