### PR TITLE
[632] Adding Editable to history tasks

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -66,7 +66,11 @@ const router = createBrowserRouter([
         ],
       },
       { path: "excel", element: <ExcelPage /> },
-      { path: "history", element: <TasksPage /> },
+      {
+        path: "history",
+        element: <TasksPage />,
+        children: [{ path: "edit/:taskId", element: <EditTaskPage /> }],
+      },
       {
         path: "timer",
         element: <TimerPage />,

--- a/src/features/tasks/components/EditTaskForm.tsx
+++ b/src/features/tasks/components/EditTaskForm.tsx
@@ -24,7 +24,7 @@ export const EditTaskForm = ({ task }: Props) => {
       },
     });
 
-    navigate("..");
+    navigate(-1);
   };
 
   return (

--- a/src/pages/Tasks/EditTaskPage.tsx
+++ b/src/pages/Tasks/EditTaskPage.tsx
@@ -23,7 +23,7 @@ export const EditTaskPage = () => {
 
   if (isPending) {
     return (
-      <Modal isOpen={isOpen} onClose={() => navigate("..")}>
+      <Modal isOpen={isOpen} onClose={() => navigate(-1)}>
         <Loading sizeStyles="size-10" className="mx-auto" />
       </Modal>
     );
@@ -31,7 +31,7 @@ export const EditTaskPage = () => {
 
   if (isError) {
     return (
-      <Modal isOpen={isOpen} onClose={() => navigate("..")}>
+      <Modal isOpen={isOpen} onClose={() => navigate(-1)}>
         <p>{error.name}</p>
         <p>{error.message}</p>
         <Button onClick={() => refetch()}>{RETRY}</Button>
@@ -40,7 +40,7 @@ export const EditTaskPage = () => {
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={() => navigate("..")}>
+    <Modal isOpen={isOpen} onClose={() => navigate(-1)}>
       <EditTaskForm task={data} />
     </Modal>
   );

--- a/src/pages/Tasks/FilterableTaskList.tsx
+++ b/src/pages/Tasks/FilterableTaskList.tsx
@@ -1,4 +1,5 @@
-import { useSearchParams } from "react-router";
+import { Link, useSearchParams } from "react-router";
+import { usePrefetchTask } from "@/features/tasks/api/tanstack/usePrefetchTask";
 import { useTasks } from "@/features/tasks/api/tanstack/useTasks";
 
 import { CompletedTask, TaskList } from "@/features/tasks/components";
@@ -6,6 +7,7 @@ import { Button } from "@/components/core";
 import { CompletedTaskAPI } from "@/features/tasks/types/completedTask";
 
 export const FilterableTaskList = () => {
+  const prefetchTask = usePrefetchTask();
   const [params] = useSearchParams();
   const dateParam = params.get("date") ?? "today";
 
@@ -21,7 +23,15 @@ export const FilterableTaskList = () => {
   return (
     <TaskList
       tasks={data}
-      renderItem={(task) => <CompletedTask task={task as CompletedTaskAPI} />}
+      renderItem={(task) => (
+        <Link
+          key={task.id}
+          to={`edit/${task.id}?date=${dateParam}`}
+          onFocus={() => prefetchTask(task.id)}
+          onMouseEnter={() => prefetchTask(task.id)}>
+          <CompletedTask task={task as CompletedTaskAPI} />
+        </Link>
+      )}
     />
   );
 };

--- a/src/pages/Tasks/TasksPage.tsx
+++ b/src/pages/Tasks/TasksPage.tsx
@@ -1,5 +1,6 @@
 import { DateFilter } from "@/components/core/Date";
 import { FilterableTaskList } from "./FilterableTaskList";
+import { Outlet } from "react-router";
 import { PageHeader } from "@/components/layout";
 
 export const TasksPage = () => {
@@ -10,6 +11,7 @@ export const TasksPage = () => {
         <DateFilter label="Date Filter" hideLabel />
       </div>
       <FilterableTaskList />
+      <Outlet />
     </div>
   );
 };


### PR DESCRIPTION
## Change Description
- Added `EditPage` as children of History.
- Added `Outlet` to `TasksPage` so it can render modals.
- Wrapped `CompletedTask` in Link so it can take to the edit page.
- Replaced `..` for `-1` to work better with both history and searchParams

## Type of Change
- [x] Bug Fix
- [x] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
