### PR TITLE
[649] IdleTimer autofocuses now

### DIFF
--- a/src/pages/timer/IdleTimer.tsx
+++ b/src/pages/timer/IdleTimer.tsx
@@ -6,6 +6,7 @@ import { ActivityComboBox } from "@/features/activities/components";
 import { IconButton } from "@/components/core";
 import { Option } from "@/types/core";
 import { PlayIcon } from "@heroicons/react/24/solid";
+import { useEffect } from "react";
 
 type FormValues = {
   activity_id: Option | null;
@@ -14,7 +15,7 @@ type FormValues = {
 export const IdleTimer = () => {
   const { mutateAsync: createTask } = useCreateTask();
   const { mutateAsync: startTask } = useStartTask();
-  const { control, formState, handleSubmit } = useForm<FormValues>({
+  const { control, formState, handleSubmit, setFocus } = useForm<FormValues>({
     defaultValues: {
       activity_id: null,
     },
@@ -28,6 +29,8 @@ export const IdleTimer = () => {
       await startTask(newTask.id);
     }
   };
+
+  useEffect(() => setFocus("activity_id"), [setFocus]);
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="flex items-center gap-2">


### PR DESCRIPTION
## Change Description
- Used a useEffect since not using it and just using the autofocus prop would mean a whole change in Typescript types which is time consuming.

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
