### PR TITLE
[762] Fix long activities taking two lines

### DIFF
--- a/src/pages/timer/RunningTimer.tsx
+++ b/src/pages/timer/RunningTimer.tsx
@@ -29,7 +29,9 @@ export const RunningTimer = ({ task }: Props) => {
         onMouseEnter={() => prefetchTask(task.id)}>
         <div className="flex items-center gap-1.5">
           <Dot sizeStyles="size-2" colorStyles={color.fillClass} />
-          <p className="text-sm font-semibold">{task.activity.name}</p>
+          <p className="line-clamp-1 text-sm font-semibold">
+            {task.activity.name}
+          </p>
         </div>
         <p className="text-xs">
           {new Date(task.start_time).toLocaleTimeString()}


### PR DESCRIPTION
## Change Description
- Long activities now clamp when their name is very long, instead of increasing timer height and shifting the layout.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
