### PR TITLE
[759] History and Excel Links for Admins

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -37,7 +37,7 @@ import {
   NewRoutinePage,
   RoutinesPage,
 } from "@/pages/routines";
-import { EditTaskPage, TasksPage } from "@/pages/Tasks";
+import { EditTaskPage, HistoryPage } from "@/pages/Tasks";
 import {
   FirstTableAttempt,
   GlobalSearchTable,
@@ -74,7 +74,7 @@ const router = createBrowserRouter([
       { path: "excel", element: <ExcelPage /> },
       {
         path: "history",
-        element: <TasksPage />,
+        element: <HistoryPage />,
         children: [{ path: "edit/:taskId", element: <EditTaskPage /> }],
       },
       {

--- a/src/features/user/components/AdminProtectedContent.tsx
+++ b/src/features/user/components/AdminProtectedContent.tsx
@@ -1,0 +1,15 @@
+import { useUser } from "../api/tanstack/useUser";
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export const AdminProtectedContent = ({ children }: Props) => {
+  const { data } = useUser();
+
+  if (data?.is_admin) {
+    return <>{children}</>;
+  }
+
+  return null;
+};

--- a/src/features/user/components/index.ts
+++ b/src/features/user/components/index.ts
@@ -1,1 +1,2 @@
+export * from "./AdminProtectedContent";
 export * from "./Username";

--- a/src/features/user/types/userSafe.ts
+++ b/src/features/user/types/userSafe.ts
@@ -3,6 +3,7 @@ export interface UserSafe {
   created_at: string;
   email_address: string;
   first_name: string;
+  is_admin: boolean;
   last_name: string | null;
   updated_at: string;
 }

--- a/src/pages/Excel/ExcelPage.tsx
+++ b/src/pages/Excel/ExcelPage.tsx
@@ -1,11 +1,20 @@
+import { AdminProtectedContent } from "@/features/user/components";
 import { DateFilter } from "@/components/core/Date";
 import { ExcelPageContent } from "./ExcelPageContent";
-import { PageHeader } from "@/components/layout";
+import { HistoryLink } from "./HistoryLink";
+import { PageHeaderWithActions } from "@/components/layout";
 
 export const ExcelPage = () => {
   return (
     <div>
-      <PageHeader title="Excel Exporter" />
+      <PageHeaderWithActions
+        title="Excel Exporter"
+        actions={
+          <AdminProtectedContent>
+            <HistoryLink />
+          </AdminProtectedContent>
+        }
+      />
       <DateFilter label="Date" hideLabel className="sm:w-1/2" />
       <ExcelPageContent />
     </div>

--- a/src/pages/Excel/HistoryLink.tsx
+++ b/src/pages/Excel/HistoryLink.tsx
@@ -1,0 +1,14 @@
+import { Link, useSearchParams } from "react-router";
+import { RectangleStackIcon } from "@heroicons/react/24/outline";
+
+export const HistoryLink = () => {
+  const [params] = useSearchParams();
+
+  const date = params.get("date") ?? "";
+
+  return (
+    <Link to={{ pathname: "/history", search: date && `?date=${date}` }}>
+      <RectangleStackIcon className="size-5" />
+    </Link>
+  );
+};

--- a/src/pages/Tasks/ExcelLink.tsx
+++ b/src/pages/Tasks/ExcelLink.tsx
@@ -1,0 +1,14 @@
+import { Link, useSearchParams } from "react-router";
+import { TableCellsIcon } from "@heroicons/react/24/outline";
+
+export const ExcelLink = () => {
+  const [params] = useSearchParams();
+
+  const date = params.get("date") ?? undefined;
+
+  return (
+    <Link to={{ pathname: "/excel", search: date && `?date=${date}` }}>
+      <TableCellsIcon className="size-5" />
+    </Link>
+  );
+};

--- a/src/pages/Tasks/HistoryPage.tsx
+++ b/src/pages/Tasks/HistoryPage.tsx
@@ -3,7 +3,7 @@ import { FilterableTaskList } from "./FilterableTaskList";
 import { Outlet } from "react-router";
 import { PageHeader } from "@/components/layout";
 
-export const TasksPage = () => {
+export const HistoryPage = () => {
   return (
     <div>
       <PageHeader title="Tasks" />

--- a/src/pages/Tasks/HistoryPage.tsx
+++ b/src/pages/Tasks/HistoryPage.tsx
@@ -1,12 +1,21 @@
+import { AdminProtectedContent } from "@/features/user/components";
 import { DateFilter } from "@/components/core/Date";
+import { ExcelLink } from "./ExcelLink";
 import { FilterableTaskList } from "./FilterableTaskList";
 import { Outlet } from "react-router";
-import { PageHeader } from "@/components/layout";
+import { PageHeaderWithActions } from "@/components/layout";
 
 export const HistoryPage = () => {
   return (
     <div>
-      <PageHeader title="Tasks" />
+      <PageHeaderWithActions
+        title="Tasks"
+        actions={
+          <AdminProtectedContent>
+            <ExcelLink />
+          </AdminProtectedContent>
+        }
+      />
       <div className="mb-2 w-2/3 md:w-1/3">
         <DateFilter label="Date Filter" hideLabel className="w-full" />
       </div>

--- a/src/pages/Tasks/index.ts
+++ b/src/pages/Tasks/index.ts
@@ -1,2 +1,2 @@
 export * from "./EditTaskPage";
-export * from "./TasksPage";
+export * from "./HistoryPage";


### PR DESCRIPTION
## Change Description
- Renamed `TasksPage` to `HistoryPage` to improve clarity
- Created `AdminProtectedContent` which will only display `children` when user is admin
- Created `ExcelLink` and `HistoryLink`

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
