### PR TITLE
[770] Sending user time to API

### DIFF
--- a/src/features/tasks/api/axios/completeTask.ts
+++ b/src/features/tasks/api/axios/completeTask.ts
@@ -3,6 +3,8 @@ import { CompletedTaskAPI } from "../../types/completedTask";
 
 export const completeTask = async (taskId: number) => {
   const URL = `${TASKS_ENDPOINT}/${taskId}/finish`;
-  const { data } = await apiV1.post<CompletedTaskAPI>(URL);
+  const { data } = await apiV1.post<CompletedTaskAPI>(URL, {
+    end_time: new Date().toISOString(),
+  });
   return data;
 };

--- a/src/features/tasks/api/axios/startTask.ts
+++ b/src/features/tasks/api/axios/startTask.ts
@@ -3,6 +3,8 @@ import { InProgressTaskAPI } from "../../types/inProgressTast";
 
 export const startTask = async (taskId: number) => {
   const URL = `${TASKS_ENDPOINT}/${taskId}/start`;
-  const { data } = await apiV1.post<InProgressTaskAPI>(URL);
+  const { data } = await apiV1.post<InProgressTaskAPI>(URL, {
+    start_time: new Date().toISOString(),
+  });
   return data;
 };


### PR DESCRIPTION
## Change Description
- Added `start_time` to start_task request
- Added `end_time` to complete_task request

## Related Tasks
[Start and Finish use FE time when available](https://github.com/brandonrq506/first_api/pull/60)

## Type of Change
- [x] Bug Fix
- [x] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
