### PR TITLE
[705] Inputs option to hide error message

### DIFF
--- a/src/components/form/ComboBox/ComboBox.tsx
+++ b/src/components/form/ComboBox/ComboBox.tsx
@@ -53,6 +53,7 @@ export const ComboBox = ({
   ref,
   config,
   description,
+  hideErrorMessage = false,
   hideLabel = false,
   label,
   options,
@@ -142,7 +143,7 @@ export const ComboBox = ({
       {description && !error && (
         <p className="mt-2 text-sm font-light text-gray-500">{description}</p>
       )}
-      {error && (
+      {error && !hideErrorMessage && (
         <p role="alert" className="mt-2 text-sm font-light text-red-600">
           {error}
         </p>

--- a/src/components/form/ComboBox/ControlComboBox.tsx
+++ b/src/components/form/ComboBox/ControlComboBox.tsx
@@ -12,6 +12,7 @@ type ControlledComboBoxProps<T extends FieldValues> = UseControllerProps<T> &
 export const ControlComboBox = <T extends FieldValues>({
   config,
   description,
+  hideErrorMessage,
   hideLabel,
   label,
   options,
@@ -23,6 +24,7 @@ export const ControlComboBox = <T extends FieldValues>({
     <ComboBox
       config={config}
       description={description}
+      hideErrorMessage={hideErrorMessage}
       hideLabel={hideLabel}
       label={label}
       options={options}

--- a/src/components/form/ComboBox/types/index.ts
+++ b/src/components/form/ComboBox/types/index.ts
@@ -11,6 +11,7 @@ export type ComboBoxType = {
   label: string;
   config?: Configuration;
   description?: string;
+  hideErrorMessage?: boolean;
   hideLabel?: boolean;
   showAsterisk?: boolean;
 };

--- a/src/components/form/NumerInput/NumberInput.spec.tsx
+++ b/src/components/form/NumerInput/NumberInput.spec.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import { NumberInput } from "./NumberInput";
+
+describe("NumberInput", () => {
+  it("renders the label and input correctly", () => {
+    render(<NumberInput label="Age" registration={{}} />);
+    expect(screen.getByLabelText(/Age/i)).toBeInTheDocument();
+  });
+
+  it("is accessible even if label is hidden", () => {
+    render(<NumberInput label="Invisible" registration={{}} hideLabel />);
+    expect(screen.getByLabelText(/invisible/i)).toBeInTheDocument();
+  });
+
+  it("displays the asterisk if showAsterisk is true", () => {
+    render(<NumberInput label="Age" showAsterisk registration={{}} />);
+    expect(screen.getByText("*")).toBeInTheDocument();
+  });
+
+  it("does not display the asterisk if showAsterisk is false", () => {
+    render(<NumberInput label="Age" registration={{}} />);
+    expect(screen.queryByText("*")).not.toBeInTheDocument();
+  });
+
+  it("renders a description if provided", () => {
+    render(
+      <NumberInput
+        label="Age"
+        registration={{}}
+        description="Enter your age"
+      />,
+    );
+    expect(screen.getByText(/Enter your age/i)).toBeInTheDocument();
+  });
+
+  it("renders an error message if error prop is provided", () => {
+    render(
+      <NumberInput label="Age" registration={{}} error="Age is required" />,
+    );
+    expect(screen.getByText(/Age is required/i)).toBeInTheDocument();
+  });
+
+  it("renders error instead of description if both are provided", () => {
+    const description = "Enter your age";
+    const error = "Age is required";
+
+    render(
+      <NumberInput
+        label="Age"
+        registration={{}}
+        description={description}
+        error={error}
+      />,
+    );
+    expect(screen.queryByText(description)).not.toBeInTheDocument();
+    expect(screen.getByText(error)).toBeInTheDocument();
+  });
+
+  it("adds aria-invalid and invalid styles when error prop is present", () => {
+    render(
+      <NumberInput
+        label="Username"
+        registration={{}}
+        error="Invalid username"
+      />,
+    );
+    const inputElement = screen.getByLabelText(/Username/i);
+    expect(inputElement).toHaveAttribute("aria-invalid");
+  });
+
+  it("does not apply error styles if no error is present", () => {
+    render(<NumberInput label="Age" registration={{}} />);
+    const inputElement = screen.getByLabelText(/Age/i);
+    expect(inputElement).not.toHaveAttribute("aria-invalid");
+  });
+
+  it("hides the error message if hideErrorMessage is true", () => {
+    render(
+      <NumberInput
+        label="Age"
+        registration={{}}
+        error="Age is required"
+        hideErrorMessage={true}
+      />,
+    );
+    expect(screen.queryByText(/Age is required/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/form/NumerInput/NumberInput.tsx
+++ b/src/components/form/NumerInput/NumberInput.tsx
@@ -7,6 +7,7 @@ type InputProps = {
   className?: string;
   description?: string;
   error?: string;
+  hideErrorMessage?: boolean;
   hideLabel?: boolean;
   label: string;
   placeholder?: string;
@@ -18,6 +19,7 @@ export const NumberInput = ({
   className,
   description,
   error,
+  hideErrorMessage = false,
   hideLabel = false,
   label,
   placeholder,
@@ -38,6 +40,7 @@ export const NumberInput = ({
             type="number"
             placeholder={placeholder}
             aria-invalid={Boolean(error)}
+            invalid={Boolean(error)}
             {...registration}
             className={clsx(
               "block w-full rounded-md border-0 py-1.5 text-sm text-gray-900 shadow-xs ring-1 ring-gray-300 ring-inset placeholder:text-gray-400 focus:ring-2 focus:ring-indigo-600 focus:ring-inset sm:leading-6",
@@ -62,7 +65,7 @@ export const NumberInput = ({
           {description}
         </Description>
       )}
-      {error && (
+      {error && !hideErrorMessage && (
         <Description
           role="alert"
           className="mt-2 text-sm font-light text-red-600">

--- a/src/components/form/Select/ControlledSelect.tsx
+++ b/src/components/form/Select/ControlledSelect.tsx
@@ -11,6 +11,8 @@ type ControlledSelectType<T extends FieldValues> = UseControllerProps<T> &
 
 export const ControlledSelect = <T extends FieldValues>({
   description,
+  hideErrorMessage = false,
+  hideLabel = false,
   label,
   options,
   showAsterisk,
@@ -20,9 +22,11 @@ export const ControlledSelect = <T extends FieldValues>({
 
   return (
     <Select
+      description={description}
+      hideErrorMessage={hideErrorMessage}
+      hideLabel={hideLabel}
       label={label}
       options={options}
-      description={description}
       showAsterisk={showAsterisk}
       error={fieldState.error?.message}
       onChange={field.onChange}

--- a/src/components/form/Select/ControlledStringSelect.tsx
+++ b/src/components/form/Select/ControlledStringSelect.tsx
@@ -12,6 +12,8 @@ type ControlledSelectType<T extends FieldValues> = UseControllerProps<T> &
 export const ControlledStringSelect = <T extends FieldValues>({
   description,
   label,
+  hideErrorMessage = false,
+  hideLabel = false,
   options,
   showAsterisk,
   ...controllerProps
@@ -20,9 +22,11 @@ export const ControlledStringSelect = <T extends FieldValues>({
 
   return (
     <StringSelect
+      description={description}
+      hideErrorMessage={hideErrorMessage}
+      hideLabel={hideLabel}
       label={label}
       options={options}
-      description={description}
       showAsterisk={showAsterisk}
       error={fieldState.error?.message}
       onChange={field.onChange}

--- a/src/components/form/Select/Select.tsx
+++ b/src/components/form/Select/Select.tsx
@@ -26,6 +26,7 @@ type Props = SelectRHFProps & SelectType;
 export const Select = ({
   ref,
   description,
+  hideErrorMessage = false,
   hideLabel = false,
   label,
   options,
@@ -98,7 +99,7 @@ export const Select = ({
           {description}
         </Description>
       )}
-      {error && (
+      {error && !hideErrorMessage && (
         <Description className="mt-2 text-sm font-light text-red-600">
           {error}
         </Description>

--- a/src/components/form/Select/StringSelect.tsx
+++ b/src/components/form/Select/StringSelect.tsx
@@ -27,6 +27,7 @@ export const StringSelect = ({
   ref,
   description,
   label,
+  hideErrorMessage = false,
   hideLabel = false,
   options,
   showAsterisk,
@@ -98,7 +99,7 @@ export const StringSelect = ({
           {description}
         </Description>
       )}
-      {error && (
+      {error && !hideErrorMessage && (
         <Description className="mt-2 text-sm font-light text-red-600">
           {error}
         </Description>

--- a/src/components/form/Select/types/index.ts
+++ b/src/components/form/Select/types/index.ts
@@ -3,6 +3,7 @@ import { Option, StringOption } from "@/types/core";
 export type SelectType = {
   description?: string;
   label: string;
+  hideErrorMessage?: boolean;
   hideLabel?: boolean;
   options: Option[];
   showAsterisk?: boolean;
@@ -11,6 +12,7 @@ export type SelectType = {
 export type StringSelectType = {
   description?: string;
   label: string;
+  hideErrorMessage?: boolean;
   hideLabel?: boolean;
   options: StringOption[];
   showAsterisk?: boolean;

--- a/src/components/form/TextInput/TextInput.spec.tsx
+++ b/src/components/form/TextInput/TextInput.spec.tsx
@@ -79,4 +79,20 @@ describe("TextInput", () => {
     const inputElement = screen.getByLabelText(/Search/i);
     expect(inputElement).toHaveAttribute("type", "text");
   });
+
+  it("hides the error message if hideErrorMessage is true", () => {
+    render(
+      <TextInput
+        label="Username"
+        registration={{}}
+        error="Username is required"
+        hideErrorMessage
+      />,
+    );
+
+    const inputElement = screen.getByLabelText(/Username/i);
+
+    expect(screen.queryByText(/Username is required/i)).not.toBeInTheDocument();
+    expect(inputElement).toHaveAttribute("aria-invalid");
+  });
 });

--- a/src/components/form/TextInput/TextInput.tsx
+++ b/src/components/form/TextInput/TextInput.tsx
@@ -32,6 +32,7 @@ type Props = CustomTextField & {
   error?: string;
   inputClassName?: string;
   label: string;
+  hideErrorMessage?: boolean;
   hideLabel?: boolean;
   registration: Partial<UseFormRegisterReturn>;
   showAsterisk?: boolean;
@@ -44,6 +45,7 @@ export const TextInput = ({
   error,
   inputClassName,
   label,
+  hideErrorMessage = false,
   hideLabel = false,
   registration,
   showAsterisk = false,
@@ -80,7 +82,7 @@ export const TextInput = ({
           {description}
         </Description>
       )}
-      {error && (
+      {error && !hideErrorMessage && (
         <Description
           role="alert"
           className="mt-2 text-sm font-light text-red-600">

--- a/src/components/form/TimeInput/TimeInputV2.tsx
+++ b/src/components/form/TimeInput/TimeInputV2.tsx
@@ -31,6 +31,7 @@ type CustomTimeProps = CustomTimeField & {
   description?: string;
   inputClassName?: string;
   label: string;
+  hideErrorMessage?: boolean;
   hideLabel?: boolean;
   showAsterisk?: boolean;
 };
@@ -50,6 +51,7 @@ export const TimeInputV2 = <T extends FieldValues>({
   description,
   inputClassName,
   label,
+  hideErrorMessage = false,
   hideLabel = false,
   showAsterisk = false,
   ...props
@@ -109,7 +111,7 @@ export const TimeInputV2 = <T extends FieldValues>({
           {description}
         </Description>
       )}
-      {fieldState.error && (
+      {fieldState.error && !hideErrorMessage && (
         <Description className="mt-2 text-sm font-light text-red-600">
           {fieldState.error.message}
         </Description>

--- a/src/features/activities/components/ActivityForm.spec.tsx
+++ b/src/features/activities/components/ActivityForm.spec.tsx
@@ -143,6 +143,13 @@ describe("ActivityForm", () => {
 
     expect(onSubmit).not.toHaveBeenCalled();
     expect(screen.getAllByText("Hours can't be negative")).toHaveLength(2);
+
+    await user.clear(screen.getByLabelText("Avg. Hours"));
+    await user.type(screen.getByLabelText("Avg. Hours"), "2");
+
+    await user.clear(screen.getByLabelText("Max. Hours"));
+    await user.type(screen.getByLabelText("Max. Hours"), "2");
+
     expect(screen.getAllByText("Minutes can't be negative")).toHaveLength(2);
   });
 

--- a/src/features/activities/components/ActivityForm.tsx
+++ b/src/features/activities/components/ActivityForm.tsx
@@ -51,99 +51,113 @@ export const ActivityForm = ({
           rules={{ required: "A category must be selected" }}
         />
 
-        <div className="flex gap-1">
-          <NumberInput
-            label="Avg. Hours"
-            placeholder="00"
-            className="flex-auto"
-            error={errors.avg_time_hours?.message}
-            registration={register("avg_time_hours", {
-              required: "At least 0 is required",
-              valueAsNumber: true,
-              min: {
-                value: 0,
-                message: "Hours can't be negative",
-              },
-              max: {
-                value: 23,
-                message: "Can't be longer than a day",
-              },
-            })}
-          />
-          <NumberInput
-            label="Avg. Minutes"
-            placeholder="30"
-            className="flex-auto"
-            error={errors.avg_time_minutes?.message}
-            registration={register("avg_time_minutes", {
-              required: "At least 0 is required",
-              valueAsNumber: true,
-              min: {
-                value: 0,
-                message: "Minutes can't be negative",
-              },
-              max: {
-                value: 59,
-                message: "Minutes must be less than an hour",
-              },
-              validate: {
-                isNotZero: (value) => {
-                  const { avg_time_hours } = getValues();
-                  if (avg_time_hours === 0 && value === 0) {
-                    return "Activities should take at least 1 minute";
-                  }
+        <div>
+          <div className="flex gap-1">
+            <NumberInput
+              label="Avg. Hours"
+              placeholder="00"
+              hideErrorMessage
+              className="flex-auto"
+              error={errors.avg_time_hours?.message}
+              registration={register("avg_time_hours", {
+                required: "At least 0 is required",
+                valueAsNumber: true,
+                min: {
+                  value: 0,
+                  message: "Hours can't be negative",
                 },
-              },
-            })}
-          />
+                max: {
+                  value: 23,
+                  message: "Can't be longer than a day",
+                },
+              })}
+            />
+            <NumberInput
+              label="Avg. Minutes"
+              placeholder="30"
+              hideErrorMessage
+              className="flex-auto"
+              error={errors.avg_time_minutes?.message}
+              registration={register("avg_time_minutes", {
+                required: "At least 0 is required",
+                valueAsNumber: true,
+                min: {
+                  value: 0,
+                  message: "Minutes can't be negative",
+                },
+                max: {
+                  value: 59,
+                  message: "Minutes must be less than an hour",
+                },
+                validate: {
+                  isNotZero: (value) => {
+                    const { avg_time_hours } = getValues();
+                    if (avg_time_hours === 0 && value === 0) {
+                      return "Activities should take at least 1 minute";
+                    }
+                  },
+                },
+              })}
+            />
+          </div>
+          <div role="alert" className="mt-2 text-sm font-light text-red-600">
+            {errors.avg_time_hours?.message || errors.avg_time_minutes?.message}
+          </div>
         </div>
 
-        <div className="flex gap-1">
-          <NumberInput
-            label="Max. Hours"
-            placeholder="01"
-            className="flex-auto"
-            error={errors.max_time_hours?.message}
-            registration={register("max_time_hours", {
-              required: "At least 0 is required",
-              valueAsNumber: true,
-              min: {
-                value: 0,
-                message: "Hours can't be negative",
-              },
-              max: {
-                value: 23,
-                message: "Can't be longer than a day",
-              },
-            })}
-          />
-
-          <NumberInput
-            label="Max. Minutes"
-            placeholder="30"
-            className="flex-auto"
-            error={errors.max_time_minutes?.message}
-            registration={register("max_time_minutes", {
-              required: "At least 0 is required",
-              valueAsNumber: true,
-              min: {
-                value: 0,
-                message: "Minutes can't be negative",
-              },
-              max: {
-                value: 59,
-                message: "Minutes must be less than an hour",
-              },
-              validate: {
-                isNotZero: (value) => {
-                  const { max_time_hours } = getValues();
-                  if (max_time_hours === 0 && value === 0) {
-                    return "Activities should take at least 1 minute";
-                  }
+        <div>
+          <div className="flex gap-1">
+            <NumberInput
+              label="Max. Hours"
+              placeholder="01"
+              hideErrorMessage
+              className="flex-auto"
+              error={errors.max_time_hours?.message}
+              registration={register("max_time_hours", {
+                required: "At least 0 is required",
+                valueAsNumber: true,
+                min: {
+                  value: 0,
+                  message: "Hours can't be negative",
                 },
-              },
-            })}
-          />
+                max: {
+                  value: 23,
+                  message: "Can't be longer than a day",
+                },
+              })}
+            />
+
+            <NumberInput
+              label="Max. Minutes"
+              placeholder="30"
+              hideErrorMessage
+              className="flex-auto"
+              error={errors.max_time_minutes?.message}
+              registration={register("max_time_minutes", {
+                required: "At least 0 is required",
+                valueAsNumber: true,
+                min: {
+                  value: 0,
+                  message: "Minutes can't be negative",
+                },
+                max: {
+                  value: 59,
+                  message: "Minutes must be less than an hour",
+                },
+                validate: {
+                  isNotZero: (value) => {
+                    const { max_time_hours } = getValues();
+                    if (max_time_hours === 0 && value === 0) {
+                      return "Activities should take at least 1 minute";
+                    }
+                  },
+                },
+              })}
+            />
+          </div>
+          <div role="alert" className="mt-2 text-sm font-light text-red-600">
+            {errors.max_time_hours?.message || errors.max_time_minutes?.message}
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Change Description
- Added `hideErrorMessage` to all inputs
- Added new tests to `NumberInput` and `TextInput`
- Modified `ActivityForm` which errors were breaking down in multiple lines before

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [x] Refactor
- [x] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [x] New tests have been added to cover the changes (if applicable).
- [x] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
