### PR TITLE
[863] Running timer displays avg_time now

### DIFF
--- a/src/pages/timer/RunningTimer.tsx
+++ b/src/pages/timer/RunningTimer.tsx
@@ -38,8 +38,8 @@ export const RunningTimer = ({ task }: Props) => {
       <div className="flex gap-x-1.5 text-sm">
         <TimerTime start_time={task.start_time} />
         <p className="font-light text-gray-700">/</p>
-        {task.activity.max_time &&
-          convertSecondsToHHMMSS(task.activity.max_time)}
+        {task.activity.avg_time &&
+          convertSecondsToHHMMSS(task.activity.avg_time)}
       </div>
 
       <RunningTimerButton task={task} />


### PR DESCRIPTION
## Change Description
- Running timer now displays `avg.time` instead of `max.time`

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
