### PR TITLE
[929] Timer now displays remaining / overtime

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from "./useDisclosure";
 export * from "./useKeyboardVisible";
 export * from "./useOnlineStatus";
+export * from "./useTimer";

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+
+import {
+  addSeconds,
+  differenceInSeconds,
+  parseISO,
+  setMilliseconds,
+} from "date-fns";
+import { millisecondsInSecond } from "date-fns/constants";
+
+interface Props {
+  start_time: string;
+  exp_seconds: number;
+}
+
+export const useTimer = ({ start_time, exp_seconds }: Props) => {
+  const [seconds, setSeconds] = useState(() => {
+    const start = parseISO(start_time);
+    const expectedEnd = addSeconds(start, exp_seconds);
+    return differenceInSeconds(expectedEnd, new Date());
+  });
+
+  useEffect(() => {
+    const tick = () => {
+      const start = parseISO(start_time);
+      const expectedEnd = addSeconds(start, exp_seconds);
+      const now = setMilliseconds(new Date(), 0);
+      const diff = differenceInSeconds(expectedEnd, now);
+      setSeconds(diff);
+    };
+
+    tick();
+    const id = setInterval(tick, millisecondsInSecond);
+    return () => clearInterval(id);
+  }, [start_time, exp_seconds]);
+
+  return seconds;
+};

--- a/src/pages/timer/RunningTimer.tsx
+++ b/src/pages/timer/RunningTimer.tsx
@@ -7,7 +7,6 @@ import { RunningTimerButton } from "./RunningTimerButton";
 import { TimerTime } from "./TimerTime";
 
 import { getColorByName } from "@/features/colors/utils/getColorByName";
-import { secondsToHHmmss } from "@/utils";
 
 type Props = {
   task: InProgressTaskAPI;
@@ -35,11 +34,10 @@ export const RunningTimer = ({ task }: Props) => {
           {new Date(task.start_time).toLocaleTimeString()}
         </p>
       </Link>
-      <div className="flex gap-x-1.5 text-sm">
-        <TimerTime start_time={task.start_time} />
-        <p className="font-light text-gray-700">/</p>
-        {secondsToHHmmss(task.activity.exp_seconds)}
-      </div>
+      <TimerTime
+        start_time={task.start_time}
+        exp_seconds={task.activity.exp_seconds}
+      />
 
       <RunningTimerButton task={task} />
     </div>

--- a/src/pages/timer/TimerTime.tsx
+++ b/src/pages/timer/TimerTime.tsx
@@ -16,7 +16,7 @@ export const TimerTime = ({ start_time, exp_seconds }: Props) => {
       <span className={clsx(seconds < 0 && "text-red-800")}>
         {secondsToHHmmss(seconds)}
       </span>
-      <p className="font-light text-gray-700">/</p>
+      <span className="font-light text-gray-700">/</span>
       {secondsToHHmmss(exp_seconds)}
     </div>
   );

--- a/src/pages/timer/TimerTime.tsx
+++ b/src/pages/timer/TimerTime.tsx
@@ -1,31 +1,23 @@
-import { useEffect, useState } from "react";
+import { useTimer } from "@/hooks";
 
+import { clsx } from "clsx";
 import { secondsToHHmmss } from "@/utils";
 
-const DELAY = 1000;
-const MILI_TO_SEC = 1000;
-
-const elapsedTime = (start_time: string) => {
-  const start = new Date(start_time);
-  const now = new Date();
-  const elapsed = (now.getTime() - start.getTime()) / MILI_TO_SEC;
-  return Math.max(0, elapsed);
-};
-
-type Props = {
+interface Props {
   start_time: string;
-};
+  exp_seconds: number;
+}
 
-export const TimerTime = ({ start_time }: Props) => {
-  const [, setTime] = useState(0);
-  const elapsedSeconds = elapsedTime(start_time);
+export const TimerTime = ({ start_time, exp_seconds }: Props) => {
+  const seconds = useTimer({ start_time, exp_seconds });
 
-  useEffect(() => {
-    const id = setInterval(() => {
-      setTime((c) => c + 1);
-    }, DELAY);
-    return () => clearInterval(id);
-  }, []);
-
-  return <div>{secondsToHHmmss(elapsedSeconds)}</div>;
+  return (
+    <div className="flex gap-x-1.5 text-sm">
+      <span className={clsx(seconds < 0 && "text-red-800")}>
+        {secondsToHHmmss(seconds)}
+      </span>
+      <p className="font-light text-gray-700">/</p>
+      {secondsToHHmmss(exp_seconds)}
+    </div>
+  );
 };

--- a/src/utils/__tests__/secondsToHHmmss.spec.ts
+++ b/src/utils/__tests__/secondsToHHmmss.spec.ts
@@ -36,15 +36,15 @@ describe("secondsToHHmmss", () => {
     expect(result).toBe(expected);
   });
 
-  it("throws an error when seconds is negative", () => {
-    const seconds = -1;
-    expect(() => secondsToHHmmss(seconds)).toThrow(
-      "Seconds must be a positive number",
-    );
-  });
-
   it("returns '01:30:00' when seconds is a float", () => {
     const seconds = 5400.345;
     expect(secondsToHHmmss(seconds)).toBe("01:30:00");
+  });
+
+  it("should convert -3661 seconds to -01:01:01", () => {
+    const seconds = -3661;
+    const expected = "-01:01:01";
+    const result = secondsToHHmmss(seconds);
+    expect(result).toBe(expected);
   });
 });

--- a/src/utils/secondsToHHmmss.ts
+++ b/src/utils/secondsToHHmmss.ts
@@ -1,9 +1,18 @@
-import { addSeconds, format, startOfToday } from "date-fns";
+import { secondsInHour, secondsInMinute } from "date-fns/constants";
 
-export const secondsToHHmmss = (seconds: number) => {
-  if (seconds < 0)
-    throw new Error(`Seconds must be a positive number. Received: ${seconds}`);
+const PADDING = 2;
 
-  const date = addSeconds(startOfToday(), seconds);
-  return format(date, "HH:mm:ss");
+export const secondsToHHmmss = (totalSeconds: number) => {
+  const sign = totalSeconds < 0 ? "-" : "";
+  const secs = Math.abs(totalSeconds);
+
+  const hours = Math.floor(secs / secondsInHour);
+  const minutes = Math.floor((secs % secondsInHour) / secondsInMinute);
+  const seconds = Math.floor(secs % secondsInMinute);
+
+  const hh = String(hours).padStart(PADDING, "0");
+  const mm = String(minutes).padStart(PADDING, "0");
+  const ss = String(seconds).padStart(PADDING, "0");
+
+  return `${sign}${hh}:${mm}:${ss}`;
 };


### PR DESCRIPTION
## Change Description
- Extracted Timer logic to `useTimer`
- useTimer returns seconds, either `remaining` or `overtime`
- Added new tests

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [x] Refactor
- [x] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [x] New tests have been added to cover the changes (if applicable).
- [x] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
