### PR TITLE
[958] Store preferences in LocalStorage

### DIFF
--- a/src/features/userPreferences/api/tanstack/useUserPreferences.ts
+++ b/src/features/userPreferences/api/tanstack/useUserPreferences.ts
@@ -1,5 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 
+import {
+  getPreferencesFromLocalStorage,
+  savePreferencesToLocalStorage,
+} from "../../utils/localStorage";
 import { USER_PREFERENCES_ENDPOINT } from "@/libs/axios";
 import { getUserPreferences } from "../axios/getUserPreferences";
 
@@ -10,7 +14,14 @@ const MINUTES = 20;
 export const useUserPreferences = () => {
   return useQuery({
     queryKey: [USER_PREFERENCES_ENDPOINT],
-    queryFn: getUserPreferences,
+    queryFn: async () => {
+      const data = await getUserPreferences();
+
+      // Save to localStorage whenever we get fresh data from API
+      savePreferencesToLocalStorage(data);
+      return data;
+    },
     staleTime: MINUTES * millisecondsInMinute,
+    initialData: getPreferencesFromLocalStorage,
   });
 };

--- a/src/features/userPreferences/hooks/useUserPreference.ts
+++ b/src/features/userPreferences/hooks/useUserPreference.ts
@@ -4,7 +4,9 @@ import { UserPreferenceKeys } from "../types/userPreferenceKeys";
 import { matchUserPreference } from "../utils/matchUserPreference";
 
 export function useUserPreference(preferenceKey: UserPreferenceKeys) {
-  const { data } = useUserPreferences();
+  const { data, isPending } = useUserPreferences();
+
+  console.log(isPending);
 
   if (!data) return undefined;
 

--- a/src/features/userPreferences/hooks/useUserPreference.ts
+++ b/src/features/userPreferences/hooks/useUserPreference.ts
@@ -6,8 +6,6 @@ import { matchUserPreference } from "../utils/matchUserPreference";
 export function useUserPreference(preferenceKey: UserPreferenceKeys) {
   const { data, isPending } = useUserPreferences();
 
-  console.log(isPending);
-
   if (!data) return undefined;
 
   return matchUserPreference(data, preferenceKey);

--- a/src/features/userPreferences/utils/localStorage.ts
+++ b/src/features/userPreferences/utils/localStorage.ts
@@ -1,0 +1,29 @@
+import { UserPreference } from "../types/userPreference";
+
+const PREFERENCES_KEY = "preferences";
+
+/**
+ * Saves user preferences to local storage
+ */
+export const savePreferencesToLocalStorage = (
+  preferences: UserPreference[],
+): void => {
+  try {
+    localStorage.setItem(PREFERENCES_KEY, JSON.stringify(preferences));
+  } catch (error) {
+    console.error("Error saving preferences to localStorage:", error);
+  }
+};
+
+/**
+ * Gets user preferences from local storage
+ */
+export const getPreferencesFromLocalStorage = (): UserPreference[] | null => {
+  try {
+    const preferences = localStorage.getItem(PREFERENCES_KEY);
+    return preferences ? JSON.parse(preferences) : null;
+  } catch (error) {
+    console.error("Error retrieving preferences from localStorage:", error);
+    return null;
+  }
+};


### PR DESCRIPTION
## Change Description
- Added functions to `retrieve` and `save` preferences to LocalStorage
- Hook `useUserPreferences` now reads `initialData` from LocalStorage
- Hook `useUserPreferences` now saves to LocalStorage everytime it gets data

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
