### PR TITLE
[1054] Preferences to use PlaceholderData

### DIFF
--- a/src/features/userPreferences/api/tanstack/useUserPreferences.ts
+++ b/src/features/userPreferences/api/tanstack/useUserPreferences.ts
@@ -22,6 +22,6 @@ export const useUserPreferences = () => {
       return data;
     },
     staleTime: MINUTES * millisecondsInMinute,
-    initialData: getPreferencesFromLocalStorage,
+    placeholderData: getPreferencesFromLocalStorage,
   });
 };

--- a/src/features/userPreferences/utils/localStorage.ts
+++ b/src/features/userPreferences/utils/localStorage.ts
@@ -18,12 +18,14 @@ export const savePreferencesToLocalStorage = (
 /**
  * Gets user preferences from local storage
  */
-export const getPreferencesFromLocalStorage = (): UserPreference[] | null => {
+export const getPreferencesFromLocalStorage = ():
+  | UserPreference[]
+  | undefined => {
   try {
     const preferences = localStorage.getItem(PREFERENCES_KEY);
-    return preferences ? JSON.parse(preferences) : null;
+    return preferences ? JSON.parse(preferences) : undefined;
   } catch (error) {
     console.error("Error retrieving preferences from localStorage:", error);
-    return null;
+    return undefined;
   }
 };


### PR DESCRIPTION
## Change Description
- Use `placeholderData` instead of `initialData`.
- Now user_preferences are loading from LocalStorage but a call is immediately made to the API to fetch user preferences (helpful if they have been changed on another device).

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [x] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [x] The feature works as expected and meets the acceptance criteria.
