### PR TITLE
[1147] Network badge now uses useTimeout

### DIFF
--- a/src/hooks/useTimeout.ts
+++ b/src/hooks/useTimeout.ts
@@ -34,7 +34,6 @@ export const useTimeout = (callback: () => void) => {
     setIsActive(true);
   }, []);
 
-  // Auto-clean on unmount (and during React 18 Strict Mode re-mount cycle)
   useEffect(() => clear, [clear]);
 
   return { start, clear, isActive };


### PR DESCRIPTION
## Change Description
- Network Badge component now uses new `useTimeout` hook.

## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [x] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
