### PR TITLE
[1175] Activities now use queryKeys

### DIFF
--- a/src/features/activities/api/axios/createActivity.ts
+++ b/src/features/activities/api/axios/createActivity.ts
@@ -3,6 +3,6 @@ import { ActivityAPI } from "../../types/activityAPI";
 import { PostActivity } from "../../types/postActivity";
 
 export const createActivity = async (activity: PostActivity) => {
-  const { data } = await apiV1.post<ActivityAPI>(ACTIVITIES_ENDPOINT, activity);
-  return data;
+  const response = await apiV1.post<ActivityAPI>(ACTIVITIES_ENDPOINT, activity);
+  return response.data;
 };

--- a/src/features/activities/api/axios/getActivities.ts
+++ b/src/features/activities/api/axios/getActivities.ts
@@ -9,6 +9,6 @@ export const getActivities = async ({
 }: QueryFunctionContext<ReturnType<typeof activityKeys.lists>>) => {
   const [{ endpoint }] = queryKey;
 
-  const { data } = await apiV1.get<ActivityAPI[]>(endpoint, { signal });
-  return data;
+  const response = await apiV1.get<ActivityAPI[]>(endpoint, { signal });
+  return response.data;
 };

--- a/src/features/activities/api/axios/getActivities.ts
+++ b/src/features/activities/api/axios/getActivities.ts
@@ -1,11 +1,14 @@
-import { ACTIVITIES_ENDPOINT, apiV1 } from "@/libs/axios";
 import { ActivityAPI } from "../../types/activityAPI";
+import { QueryFunctionContext } from "@tanstack/react-query";
+import { activityKeys } from "../queryKeys";
+import { apiV1 } from "@/libs/axios";
 
-type Props = { signal: AbortSignal };
+export const getActivities = async ({
+  signal,
+  queryKey,
+}: QueryFunctionContext<ReturnType<typeof activityKeys.lists>>) => {
+  const [{ endpoint }] = queryKey;
 
-export const getActivities = async ({ signal }: Props) => {
-  const { data } = await apiV1.get<ActivityAPI[]>(ACTIVITIES_ENDPOINT, {
-    signal,
-  });
+  const { data } = await apiV1.get<ActivityAPI[]>(endpoint, { signal });
   return data;
 };

--- a/src/features/activities/api/axios/getActivity.ts
+++ b/src/features/activities/api/axios/getActivity.ts
@@ -10,6 +10,6 @@ export const getActivity = async ({
   const [{ endpoint, activityId }] = queryKey;
   const URL = `${endpoint}/${activityId}`;
 
-  const { data } = await apiV1.get<ActivityAPI>(URL, { signal });
-  return data;
+  const response = await apiV1.get<ActivityAPI>(URL, { signal });
+  return response.data;
 };

--- a/src/features/activities/api/axios/getActivity.ts
+++ b/src/features/activities/api/axios/getActivity.ts
@@ -1,13 +1,15 @@
-import { ACTIVITIES_ENDPOINT, apiV1 } from "@/libs/axios";
 import { ActivityAPI } from "../../types/activityAPI";
+import { QueryFunctionContext } from "@tanstack/react-query";
+import { activityKeys } from "../queryKeys";
+import { apiV1 } from "@/libs/axios";
 
-type Props = {
-  activityId: number;
-  signal: AbortSignal;
-};
+export const getActivity = async ({
+  signal,
+  queryKey,
+}: QueryFunctionContext<ReturnType<(typeof activityKeys)["detail"]>>) => {
+  const [{ endpoint, activityId }] = queryKey;
+  const URL = `${endpoint}/${activityId}`;
 
-export const getActivity = async ({ activityId, signal }: Props) => {
-  const URL = `${ACTIVITIES_ENDPOINT}/${activityId}`;
-  const response = await apiV1.get<ActivityAPI>(URL, { signal });
-  return response.data;
+  const { data } = await apiV1.get<ActivityAPI>(URL, { signal });
+  return data;
 };

--- a/src/features/activities/api/axios/updateActivity.ts
+++ b/src/features/activities/api/axios/updateActivity.ts
@@ -10,6 +10,6 @@ type Props = {
 export const updateActivity = async ({ activityId, activity }: Props) => {
   const URL = `${ACTIVITIES_ENDPOINT}/${activityId}`;
 
-  const { data } = await apiV1.patch<ActivityAPI>(URL, activity);
-  return data;
+  const response = await apiV1.patch<ActivityAPI>(URL, activity);
+  return response.data;
 };

--- a/src/features/activities/api/queryKeys.ts
+++ b/src/features/activities/api/queryKeys.ts
@@ -1,0 +1,9 @@
+import { ACTIVITIES_ENDPOINT } from "@/libs/axios";
+
+export const activityKeys = {
+  all: [{ endpoint: ACTIVITIES_ENDPOINT }] as const,
+  lists: () => [{ ...activityKeys.all[0], entity: "list" }] as const,
+  details: () => [{ ...activityKeys.all[0], entity: "details" }] as const,
+  detail: (activityId: number) =>
+    [{ ...activityKeys.details()[0], activityId }] as const,
+};

--- a/src/features/activities/api/tanstack/useActivities.ts
+++ b/src/features/activities/api/tanstack/useActivities.ts
@@ -1,11 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { ACTIVITIES_ENDPOINT } from "@/libs/axios";
+import { activityKeys } from "../queryKeys";
 import { getActivities } from "../axios/getActivities";
 
 export const useActivities = () => {
   return useQuery({
-    queryKey: [ACTIVITIES_ENDPOINT],
+    queryKey: activityKeys.lists(),
     queryFn: getActivities,
   });
 };

--- a/src/features/activities/api/tanstack/useActivity.ts
+++ b/src/features/activities/api/tanstack/useActivity.ts
@@ -1,13 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { ACTIVITIES_ENDPOINT } from "@/libs/axios";
+import { activityKeys } from "../queryKeys";
 import { getActivity } from "../axios/getActivity";
 
 export const useActivity = (activityId: number) => {
   return useQuery({
-    queryKey: [ACTIVITIES_ENDPOINT, activityId],
-    // Todo: Time to add activityKeys
-    queryFn: ({ signal }) => getActivity({ activityId, signal }),
+    queryKey: activityKeys.detail(activityId),
+    queryFn: getActivity,
     enabled: Boolean(activityId),
   });
 };

--- a/src/features/activities/api/tanstack/useCreateActivity.ts
+++ b/src/features/activities/api/tanstack/useCreateActivity.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-import { ACTIVITIES_ENDPOINT } from "@/libs/axios";
+import { activityKeys } from "../queryKeys";
 import { createActivity } from "../axios/createActivity";
 
 export const useCreateActivity = () => {
@@ -9,7 +9,7 @@ export const useCreateActivity = () => {
   return useMutation({
     mutationFn: createActivity,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [ACTIVITIES_ENDPOINT] });
+      queryClient.invalidateQueries({ queryKey: activityKeys.lists() });
     },
   });
 };

--- a/src/features/activities/api/tanstack/useDeleteActivity.ts
+++ b/src/features/activities/api/tanstack/useDeleteActivity.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-import { ACTIVITIES_ENDPOINT } from "@/libs/axios";
+import { activityKeys } from "../queryKeys";
 import { deleteActivity } from "../axios/deleteActivity";
 
 export const useDeleteActivity = () => {
@@ -8,7 +8,7 @@ export const useDeleteActivity = () => {
   return useMutation({
     mutationFn: deleteActivity,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [ACTIVITIES_ENDPOINT] });
+      queryClient.invalidateQueries({ queryKey: activityKeys.lists() });
     },
   });
 };

--- a/src/features/activities/api/tanstack/useUpdateActivity.ts
+++ b/src/features/activities/api/tanstack/useUpdateActivity.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-import { ACTIVITIES_ENDPOINT } from "@/libs/axios";
+import { activityKeys } from "../queryKeys";
 import { updateActivity } from "../axios/updateActivity";
 
 export const useUpdateActivity = () => {
@@ -9,7 +9,7 @@ export const useUpdateActivity = () => {
   return useMutation({
     mutationFn: updateActivity,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [ACTIVITIES_ENDPOINT] });
+      queryClient.invalidateQueries({ queryKey: activityKeys.lists() });
     },
   });
 };

--- a/src/features/auth/api/axios/login.ts
+++ b/src/features/auth/api/axios/login.ts
@@ -6,6 +6,6 @@ type Response = {
 };
 
 export const login = async (formValues: LoginFormType) => {
-  const { data } = await apiV1.post<Response>(SESSION_ENDPOINT, formValues);
-  return data;
+  const response = await apiV1.post<Response>(SESSION_ENDPOINT, formValues);
+  return response.data;
 };

--- a/src/features/categories/api/axios/createCategory.ts
+++ b/src/features/categories/api/axios/createCategory.ts
@@ -3,6 +3,6 @@ import { Category } from "../../types/category";
 import { PostCategory } from "../../types/postCategory";
 
 export const createCategory = async (category: PostCategory) => {
-  const { data } = await apiV1.post<Category>(CATEGORIES_ENDPOINT, category);
-  return data;
+  const response = await apiV1.post<Category>(CATEGORIES_ENDPOINT, category);
+  return response.data;
 };

--- a/src/features/categories/api/axios/getCategories.ts
+++ b/src/features/categories/api/axios/getCategories.ts
@@ -4,6 +4,6 @@ import { Category } from "../../types/category";
 type Props = { signal: AbortSignal };
 
 export const getCategories = async ({ signal }: Props) => {
-  const { data } = await apiV1.get<Category[]>(CATEGORIES_ENDPOINT, { signal });
-  return data;
+  const response = await apiV1.get<Category[]>(CATEGORIES_ENDPOINT, { signal });
+  return response.data;
 };

--- a/src/features/categories/api/axios/getCategory.ts
+++ b/src/features/categories/api/axios/getCategory.ts
@@ -8,6 +8,6 @@ type Props = {
 
 export const getCategory = async ({ categoryId, signal }: Props) => {
   const URL = `${CATEGORIES_ENDPOINT}/${categoryId}`;
-  const { data } = await apiV1.get<Category>(URL, { signal });
-  return data;
+  const response = await apiV1.get<Category>(URL, { signal });
+  return response.data;
 };

--- a/src/features/excel/api/axios/getExcel.ts
+++ b/src/features/excel/api/axios/getExcel.ts
@@ -7,7 +7,7 @@ type Props = {
 };
 
 export const getExcel = async ({ signal, date }: Props) => {
-  const { data } = await apiV1.get<ExcelTableRow[]>(EXCEL_ENDPOINT, {
+  const response = await apiV1.get<ExcelTableRow[]>(EXCEL_ENDPOINT, {
     signal,
     params: {
       date,
@@ -15,5 +15,5 @@ export const getExcel = async ({ signal, date }: Props) => {
     },
   });
 
-  return data;
+  return response.data;
 };

--- a/src/features/routines/api/axios/applyRoutine.ts
+++ b/src/features/routines/api/axios/applyRoutine.ts
@@ -3,6 +3,6 @@ import { Routine } from "../../types/routine";
 
 export const applyRoutine = async (routineId: number) => {
   const URL = `${ROUTINES_ENDPOINT}/${routineId}/apply`;
-  const { data } = await apiV1.post<Routine>(URL);
-  return data;
+  const response = await apiV1.post<Routine>(URL);
+  return response.data;
 };

--- a/src/features/routines/api/axios/createActivityRoutine.ts
+++ b/src/features/routines/api/axios/createActivityRoutine.ts
@@ -10,7 +10,7 @@ export const createActivityRoutine = async ({
   routineId,
 }: Props) => {
   const URL = `${ROUTINES_ENDPOINT}/${routineId}${ACTIVITIES_ENDPOINT}`;
-  const { data } = await apiV1.post(URL, { activity_id: activityId });
+  const response = await apiV1.post(URL, { activity_id: activityId });
 
-  return data;
+  return response.data;
 };

--- a/src/features/routines/api/axios/createRoutine.ts
+++ b/src/features/routines/api/axios/createRoutine.ts
@@ -3,6 +3,6 @@ import { Routine } from "../../types/routine";
 import { RoutineForm } from "../../types/routineForm";
 
 export const createRoutine = async (routine: RoutineForm) => {
-  const { data } = await apiV1.post<Routine>(ROUTINES_ENDPOINT, routine);
-  return data;
+  const response = await apiV1.post<Routine>(ROUTINES_ENDPOINT, routine);
+  return response.data;
 };

--- a/src/features/routines/api/axios/getRoutines.ts
+++ b/src/features/routines/api/axios/getRoutines.ts
@@ -4,6 +4,6 @@ import { Routine } from "../../types/routine";
 type Props = { signal: AbortSignal };
 
 export const getRoutines = async ({ signal }: Props) => {
-  const { data } = await apiV1.get<Routine[]>(ROUTINES_ENDPOINT, { signal });
-  return data;
+  const response = await apiV1.get<Routine[]>(ROUTINES_ENDPOINT, { signal });
+  return response.data;
 };

--- a/src/features/routines/api/axios/updateRoutine.ts
+++ b/src/features/routines/api/axios/updateRoutine.ts
@@ -10,6 +10,6 @@ type Props = {
 export const updateRoutine = async ({ routineId, routine }: Props) => {
   const URL = `${ROUTINES_ENDPOINT}/${routineId}`;
 
-  const { data } = await apiV1.patch<Routine>(URL, routine);
-  return data;
+  const response = await apiV1.patch<Routine>(URL, routine);
+  return response.data;
 };

--- a/src/features/tasks/api/axios/activateTask.ts
+++ b/src/features/tasks/api/axios/activateTask.ts
@@ -12,6 +12,6 @@ export const activateTask = async ({
   timestamp,
 }: ActivateTaskInput) => {
   const URL = `${TASKS_ENDPOINT}/${taskId}/activate`;
-  const { data } = await apiV1.post<TaskActivateResponse>(URL, { timestamp });
-  return data;
+  const response = await apiV1.post<TaskActivateResponse>(URL, { timestamp });
+  return response.data;
 };

--- a/src/features/tasks/api/axios/completeTask.ts
+++ b/src/features/tasks/api/axios/completeTask.ts
@@ -4,6 +4,6 @@ import { CompletedTaskAPI } from "../../types/completedTask";
 export const completeTask = async (task: CompletedTaskAPI) => {
   const URL = `${TASKS_ENDPOINT}/${task.id}`;
 
-  const { data } = await apiV1.patch<CompletedTaskAPI>(URL, task);
-  return data;
+  const response = await apiV1.patch<CompletedTaskAPI>(URL, task);
+  return response.data;
 };

--- a/src/features/tasks/api/axios/createQuickTask.ts
+++ b/src/features/tasks/api/axios/createQuickTask.ts
@@ -3,8 +3,8 @@ import { ActivityAPI } from "@/features/activities/types/activityAPI";
 import { TaskAPI } from "../../types/task";
 
 export const createQuickTask = async (activity: ActivityAPI) => {
-  const { data } = await apiV1.post<TaskAPI>(TASKS_ENDPOINT, {
+  const response = await apiV1.post<TaskAPI>(TASKS_ENDPOINT, {
     activity_id: activity.id,
   });
-  return data;
+  return response.data;
 };

--- a/src/features/tasks/api/axios/createTask.ts
+++ b/src/features/tasks/api/axios/createTask.ts
@@ -3,6 +3,6 @@ import { TaskAPI } from "../../types/task";
 import { TaskModel } from "../../types/taskModel";
 
 export const createTask = async (task: Partial<TaskModel>) => {
-  const { data } = await apiV1.post<TaskAPI>(TASKS_ENDPOINT, task);
-  return data;
+  const response = await apiV1.post<TaskAPI>(TASKS_ENDPOINT, task);
+  return response.data;
 };

--- a/src/features/tasks/api/axios/getTask.ts
+++ b/src/features/tasks/api/axios/getTask.ts
@@ -1,17 +1,15 @@
-import { TASKS_ENDPOINT, apiV1 } from "@/libs/axios";
 import { QueryFunctionContext } from "@tanstack/react-query";
 import { TaskAPI } from "../../types/task";
+import { apiV1 } from "@/libs/axios";
 import { taskKeys } from "../queryKeys";
 
 export const getTask = async ({
   signal,
   queryKey,
 }: QueryFunctionContext<ReturnType<(typeof taskKeys)["detail"]>>) => {
-  const [{ taskId }] = queryKey;
-  const URL = `${TASKS_ENDPOINT}/${taskId}`;
+  const [{ endpoint, taskId }] = queryKey;
+  const URL = `${endpoint}/${taskId}`;
 
-  const { data } = await apiV1.get<TaskAPI>(URL, {
-    signal,
-  });
+  const { data } = await apiV1.get<TaskAPI>(URL, { signal });
   return data;
 };

--- a/src/features/tasks/api/axios/getTask.ts
+++ b/src/features/tasks/api/axios/getTask.ts
@@ -10,6 +10,6 @@ export const getTask = async ({
   const [{ endpoint, taskId }] = queryKey;
   const URL = `${endpoint}/${taskId}`;
 
-  const { data } = await apiV1.get<TaskAPI>(URL, { signal });
-  return data;
+  const response = await apiV1.get<TaskAPI>(URL, { signal });
+  return response.data;
 };

--- a/src/features/tasks/api/axios/getTasks.ts
+++ b/src/features/tasks/api/axios/getTasks.ts
@@ -1,14 +1,14 @@
-import { TASKS_ENDPOINT, apiV1 } from "@/libs/axios";
 import { QueryFunctionContext } from "@tanstack/react-query";
 import { TaskAPI } from "../../types/task";
+import { apiV1 } from "@/libs/axios";
 import { taskKeys } from "../queryKeys";
 
 export async function getTasks<T = TaskAPI[]>({
   signal,
   queryKey,
 }: QueryFunctionContext<ReturnType<typeof taskKeys.list>>): Promise<T> {
-  const [{ filter, sort }] = queryKey;
-  const { data } = await apiV1.get<T>(TASKS_ENDPOINT, {
+  const [{ endpoint, filter, sort }] = queryKey;
+  const { data } = await apiV1.get<T>(endpoint, {
     signal,
     params: {
       filter,

--- a/src/features/tasks/api/axios/getTasks.ts
+++ b/src/features/tasks/api/axios/getTasks.ts
@@ -8,7 +8,7 @@ export async function getTasks<T = TaskAPI[]>({
   queryKey,
 }: QueryFunctionContext<ReturnType<typeof taskKeys.list>>): Promise<T> {
   const [{ endpoint, filter, sort }] = queryKey;
-  const { data } = await apiV1.get<T>(endpoint, {
+  const response = await apiV1.get<T>(endpoint, {
     signal,
     params: {
       filter,
@@ -18,5 +18,5 @@ export async function getTasks<T = TaskAPI[]>({
       },
     },
   });
-  return data;
+  return response.data;
 }

--- a/src/features/tasks/api/axios/restartTask.ts
+++ b/src/features/tasks/api/axios/restartTask.ts
@@ -3,6 +3,6 @@ import { ScheduledTaskAPI } from "../../types/scheduledTask";
 
 export const restartTask = async (taskId: number) => {
   const URL = `${TASKS_ENDPOINT}/${taskId}/restart`;
-  const { data } = await apiV1.post<ScheduledTaskAPI>(URL);
-  return data;
+  const response = await apiV1.post<ScheduledTaskAPI>(URL);
+  return response.data;
 };

--- a/src/features/tasks/api/axios/startTask.ts
+++ b/src/features/tasks/api/axios/startTask.ts
@@ -4,6 +4,6 @@ import { InProgressTaskAPI } from "../../types/inProgressTask";
 export const startTask = async (task: InProgressTaskAPI) => {
   const URL = `${TASKS_ENDPOINT}/${task.id}`;
 
-  const { data } = await apiV1.patch<InProgressTaskAPI>(URL, task);
-  return data;
+  const response = await apiV1.patch<InProgressTaskAPI>(URL, task);
+  return response.data;
 };

--- a/src/features/tasks/api/axios/updateTask.ts
+++ b/src/features/tasks/api/axios/updateTask.ts
@@ -10,6 +10,6 @@ type Props = {
 export const updateTask = async ({ taskId, task }: Props) => {
   const URL = `${TASKS_ENDPOINT}/${taskId}`;
 
-  const { data } = await apiV1.patch<TaskAPI>(URL, task);
-  return data;
+  const response = await apiV1.patch<TaskAPI>(URL, task);
+  return response.data;
 };

--- a/src/features/tasks/api/queryKeys.ts
+++ b/src/features/tasks/api/queryKeys.ts
@@ -2,7 +2,7 @@ import { TASKS_ENDPOINT } from "@/libs/axios";
 import { TaskOptions } from "../types/taskOptions";
 
 export const taskKeys = {
-  all: [{ scope: TASKS_ENDPOINT }] as const,
+  all: [{ endpoint: TASKS_ENDPOINT }] as const,
   lists: () => [{ ...taskKeys.all[0], entity: "list" }] as const,
   list: ({ filter = {}, sort = {} }: TaskOptions) =>
     [{ ...taskKeys.lists()[0], filter, sort }] as const,


### PR DESCRIPTION
## Change Description
- Created `activityKeys`.
- Implemented those in every activities endpoint.
- Activity GET endpoints now use `QueryFunctionContext`.
- Replaced `const { data }` with `const response`.

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [x] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
