### PR TITLE
[1177] Improved autofocus behavior

### DIFF
--- a/src/features/tasks/components/ScheduledTaskForm.tsx
+++ b/src/features/tasks/components/ScheduledTaskForm.tsx
@@ -43,7 +43,7 @@ export const ScheduledTaskForm = ({ initialValues, task, onSubmit }: Props) => {
       <br />
 
       <TextArea
-        autoFocus
+        autoFocus={Boolean(!initialValues.note)}
         label="Notes:"
         autoComplete="off"
         registration={register("note", {

--- a/src/features/tasks/components/__tests__/ScheduledTaskForm.spec.tsx
+++ b/src/features/tasks/components/__tests__/ScheduledTaskForm.spec.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@/test/test-utils";
+
+import { ScheduledTaskForm } from "../ScheduledTaskForm";
+
+import { scheduledTasks } from "@/test/store/tasks";
+
+describe("ScheduledTaskForm", () => {
+  it("does not focus notes when an existing note is present", () => {
+    const taskWithNote = scheduledTasks.find(
+      (t) => t.note && t.note.length > 0,
+    )!;
+
+    render(
+      <ScheduledTaskForm
+        task={taskWithNote}
+        onSubmit={vi.fn()}
+        initialValues={{ note: taskWithNote.note }}
+      />,
+    );
+
+    const notes = screen.getByLabelText("Notes:");
+    expect(notes).toBeInTheDocument();
+    expect(notes).not.toHaveFocus();
+  });
+
+  it("auto-focuses notes when no note is present", async () => {
+    const taskWithoutNote = scheduledTasks.find((t) => !t.note)!;
+
+    render(
+      <ScheduledTaskForm
+        task={taskWithoutNote}
+        onSubmit={vi.fn()}
+        initialValues={{ note: taskWithoutNote.note }}
+      />,
+    );
+
+    const notes = await screen.findByLabelText("Notes:");
+    expect(notes).toBeInTheDocument();
+    expect(notes).toHaveFocus();
+  });
+});


### PR DESCRIPTION
## Change Description
- Note input is now focused only when there is no note in a Scheduled Task.

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [x] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [x] New tests have been added to cover the changes (if applicable).
- [x] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
