### PR TITLE
[1184] Improved handling of start time onSubmit.

### DIFF
--- a/src/features/tasks/components/EditInProgressTaskForm.tsx
+++ b/src/features/tasks/components/EditInProgressTaskForm.tsx
@@ -1,10 +1,12 @@
 import { useNavigate } from "react-router";
 import { useUpdateTask } from "../api/tanstack/useUpdateTask";
 
+import { DirtyFields } from "@/types/core";
 import { InProgressFormType } from "../types/inProgressFormType";
 import { InProgressTaskAPI } from "../types/inProgressTask";
 import { InProgressTaskForm } from "./InProgressTaskForm";
 import { adjustInProgressStartTime } from "../utils/adjustInProgressStartTime";
+import { floorSeconds } from "@/utils";
 
 type Props = {
   task: InProgressTaskAPI;
@@ -14,12 +16,17 @@ export const EditInProgressTaskForm = ({ task }: Props) => {
   const navigate = useNavigate();
   const { mutate } = useUpdateTask();
 
-  const handleSubmit = (data: InProgressFormType) => {
+  const handleSubmit = (
+    data: InProgressFormType,
+    dirtyFields: DirtyFields<InProgressFormType>,
+  ) => {
     mutate({
       taskId: task.id,
       task: {
         activity_id: data.activity.value,
-        start_time: adjustInProgressStartTime(data.start_time).toISOString(),
+        start_time: dirtyFields.start_time
+          ? floorSeconds(data.start_time).toISOString()
+          : adjustInProgressStartTime(data.start_time).toISOString(),
         note: data.note,
       },
     });

--- a/src/features/tasks/components/InProgressTaskForm.tsx
+++ b/src/features/tasks/components/InProgressTaskForm.tsx
@@ -4,6 +4,7 @@ import { TextArea, TimeInputV2 } from "@/components/form";
 import { ActivityComboBox } from "@/features/activities/components";
 import { Button } from "@/components/core";
 import { CategoryBadge } from "@/features/categories/components";
+import { DirtyFields } from "@/types/core";
 import { InProgressFormType } from "../types/inProgressFormType";
 import { InProgressTaskAPI } from "../types/inProgressTask";
 
@@ -15,7 +16,10 @@ import { floorSeconds } from "@/utils";
 
 type Props = {
   initialValues: InProgressFormType;
-  onSubmit: (data: InProgressFormType) => void;
+  onSubmit: (
+    data: InProgressFormType,
+    dirtyFields: DirtyFields<InProgressFormType>,
+  ) => void;
   task: InProgressTaskAPI;
 };
 
@@ -28,11 +32,11 @@ export const InProgressTaskForm = ({
     useForm<InProgressFormType>({
       values: initialValues,
     });
-  const { isSubmitting, errors } = formState;
+  const { isSubmitting, errors, dirtyFields } = formState;
 
   return (
     <form
-      onSubmit={handleSubmit((data) => onSubmit(data))}
+      onSubmit={handleSubmit((data) => onSubmit(data, dirtyFields))}
       className="flex flex-col gap-y-2">
       <div className="flex items-center justify-between gap-2">
         <ActivityComboBox control={control} name="activity" hideLabel />

--- a/src/types/core/form.ts
+++ b/src/types/core/form.ts
@@ -1,0 +1,5 @@
+import { FieldNamesMarkedBoolean, FieldValues } from "react-hook-form";
+
+export type DirtyFields<T extends FieldValues> = Partial<
+  Readonly<FieldNamesMarkedBoolean<T>>
+>;

--- a/src/types/core/index.ts
+++ b/src/types/core/index.ts
@@ -1,4 +1,5 @@
 export type { BaseEntity } from "./baseEntity";
+export type { DirtyFields } from "./form";
 export type { Option } from "./option";
 export type { SortParams } from "./sortParams";
 export type { StringOption } from "./stringOption";


### PR DESCRIPTION
## Change Description
- Form now passes `dirtyFields`
- If `start_time` is dirty, then we just floor seconds and milliseconds.
- If `start_time` is not dirty, we evaluate if round-up, round-down or leaving as-is is the best thing to do.

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [x] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
