### PR TITLE
[1193] Scheduled and Completed task lists now have the same margins

### DIFF
--- a/src/features/tasks/components/TaskList.tsx
+++ b/src/features/tasks/components/TaskList.tsx
@@ -11,11 +11,9 @@ export const TaskList = <T extends BaseEntity>({
   renderItem,
 }: Props<T>) => {
   return (
-    <ul>
+    <ul className="space-y-3">
       {tasks.map((task) => (
-        <li key={task.id} className="my-1">
-          {renderItem(task)}
-        </li>
+        <li key={task.id}>{renderItem(task)}</li>
       ))}
 
       {tasks.length === 0 && <TaskEmptyList />}


### PR DESCRIPTION
## Change Description
- Completed Tasks list now has `space-y-3`, same as Scheduled Tasks list

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other (specify: **\_\_\_**)

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
