### PR TITLE
[898] Replace manual constants with date-fns ones

### DIFF
--- a/src/features/activities/utils/convertSecondsToHHandMM.ts
+++ b/src/features/activities/utils/convertSecondsToHHandMM.ts
@@ -1,12 +1,11 @@
-const SECONDS_IN_HOUR = 3600;
-const SECONDS_IN_MINUTE = 60;
+import { secondsInHour, secondsInMinute } from "date-fns/constants";
 
 export const convertSecondsToHHandMM = (seconds: number) => {
   if (seconds < 0)
     throw new Error(`Seconds must be a positive number. Received: ${seconds}`);
 
-  const hours = Math.floor(seconds / SECONDS_IN_HOUR);
-  const minutes = Math.floor((seconds % SECONDS_IN_HOUR) / SECONDS_IN_MINUTE);
+  const hours = Math.floor(seconds / secondsInHour);
+  const minutes = Math.floor((seconds % secondsInHour) / secondsInMinute);
 
   return { hours, minutes };
 };

--- a/src/features/activities/utils/hhmmToSeconds.ts
+++ b/src/features/activities/utils/hhmmToSeconds.ts
@@ -1,5 +1,4 @@
-const SECONDS_IN_HOUR = 3600;
-const SECONDS_IN_MINUTE = 60;
+import { secondsInHour, secondsInMinute } from "date-fns/constants";
 
 type Props = {
   hours: number;
@@ -13,9 +12,9 @@ export const hhmmToSeconds = ({ hours, minutes }: Props) => {
 
   if (hours === 0 && minutes === 0) return 0;
 
-  if (hours === 0) return minutes * SECONDS_IN_MINUTE;
+  if (hours === 0) return minutes * secondsInMinute;
 
-  if (minutes === 0) return hours * SECONDS_IN_HOUR;
+  if (minutes === 0) return hours * secondsInHour;
 
-  return hours * SECONDS_IN_HOUR + minutes * SECONDS_IN_MINUTE;
+  return hours * secondsInHour + minutes * secondsInMinute;
 };

--- a/src/features/tasks/utils/getDurationInSeconds.ts
+++ b/src/features/tasks/utils/getDurationInSeconds.ts
@@ -1,8 +1,8 @@
-const MILLIS_IN_SECOND = 1000;
+import { millisecondsInSecond } from "date-fns/constants";
 
 export const getDurationInSeconds = (start: string, end: string) => {
   const startTime = new Date(start).getTime();
   const endTime = new Date(end).getTime();
 
-  return (endTime - startTime) / MILLIS_IN_SECOND;
+  return (endTime - startTime) / millisecondsInSecond;
 };

--- a/src/utils/secondsToTime.ts
+++ b/src/utils/secondsToTime.ts
@@ -1,6 +1,8 @@
-const SECONDS_IN_HOUR = 3600;
-const SECONDS_IN_MINUTE = 60;
-const SECONDS_IN_DAY = 86400;
+import {
+  secondsInDay,
+  secondsInHour,
+  secondsInMinute,
+} from "date-fns/constants";
 
 const padNumber = (number: number) => {
   const PADDING = 2;
@@ -20,12 +22,12 @@ const displayMinutes = (minutes: number, seconds: number) => {
 
 export const secondsToTime = (seconds: number) => {
   if (seconds < 0) throw new Error("Seconds must be a positive number");
-  if (seconds > SECONDS_IN_DAY)
+  if (seconds > secondsInDay)
     throw new Error("Seconds must be less than a day");
 
-  const hours = Math.floor(seconds / SECONDS_IN_HOUR);
-  const minutes = Math.floor((seconds % SECONDS_IN_HOUR) / SECONDS_IN_MINUTE);
-  const remainingSeconds = Math.floor(seconds % SECONDS_IN_MINUTE);
+  const hours = Math.floor(seconds / secondsInHour);
+  const minutes = Math.floor((seconds % secondsInHour) / secondsInMinute);
+  const remainingSeconds = Math.floor(seconds % secondsInMinute);
 
   if (hours >= 1) return displayHours(hours, minutes, remainingSeconds);
 


### PR DESCRIPTION
## Change Description
- Removed all constans related to `milliseconds_in_second`, `seconds_in_x`, etc.
- Use date-fns built-in constants

## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [x] Refactor
- [ ] Documentation Improvement
- [ ] Other:

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
