### PR TITLE
[1268] Autopopulate display name input

### DIFF
--- a/src/features/activities/components/ActivityNameFields.tsx
+++ b/src/features/activities/components/ActivityNameFields.tsx
@@ -5,9 +5,30 @@ import { TextInput } from "@/components/form";
 
 export const ActivityNameFields = () => {
   const {
-    formState: { errors },
+    formState: { errors, dirtyFields },
+    getValues,
     register,
+    setValue,
   } = useFormContext<CreateForm>();
+
+  const handleNameBlur = () => {
+    if (!dirtyFields.name) {
+      return;
+    }
+
+    const displayName = getValues("display_name");
+    if (displayName.trim().length > 0) {
+      return;
+    }
+
+    const nameValue = getValues("name");
+
+    if (nameValue.trim().length === 0) {
+      return;
+    }
+
+    setValue("display_name", nameValue, { shouldDirty: true });
+  };
 
   return (
     <>
@@ -18,7 +39,10 @@ export const ActivityNameFields = () => {
         placeholder="Shower"
         description="Used for reports and exports."
         error={errors.name?.message}
-        registration={register("name", { required: "Name is required" })}
+        registration={register("name", {
+          required: "Name is required",
+          onBlur: handleNameBlur,
+        })}
       />
 
       <TextInput

--- a/src/features/activities/components/__tests__/ActivityNameFields.spec.tsx
+++ b/src/features/activities/components/__tests__/ActivityNameFields.spec.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@/test/test-utils";
+import { ActivityForm } from "../ActivityForm";
+import userEvent from "@testing-library/user-event";
+
+describe("ActivityNameFields", () => {
+  it("auto fills display name from name when left blank", async () => {
+    const user = userEvent.setup();
+    render(<ActivityForm onSubmit={vi.fn()} submitButtonText="Submit" />);
+
+    const nameInput = screen.getByLabelText("Name *");
+    const displayNameInput = screen.getByLabelText("Display Name");
+
+    await user.type(nameInput, "Morning Run");
+    await user.tab();
+
+    expect(displayNameInput).toHaveValue("Morning Run");
+
+    await user.clear(displayNameInput);
+    await user.type(displayNameInput, "   ");
+
+    await user.click(nameInput);
+    await user.tab();
+
+    expect(displayNameInput).toHaveValue("Morning Run");
+  });
+
+  it("allows overriding display name without further auto fills", async () => {
+    const user = userEvent.setup();
+    render(<ActivityForm onSubmit={vi.fn()} submitButtonText="Submit" />);
+
+    const nameInput = screen.getByLabelText("Name *");
+    const displayNameInput = screen.getByLabelText("Display Name");
+
+    await user.type(nameInput, "Morning Run");
+    await user.tab();
+
+    await user.clear(displayNameInput);
+    await user.type(displayNameInput, "Evening Routine");
+
+    await user.click(nameInput);
+    await user.clear(nameInput);
+    await user.type(nameInput, "Morning Routine");
+    await user.tab();
+
+    expect(displayNameInput).toHaveValue("Evening Routine");
+  });
+
+  it("does not auto fill when the name was not modified", async () => {
+    const user = userEvent.setup();
+    render(
+      <ActivityForm
+        onSubmit={vi.fn()}
+        submitButtonText="Submit"
+        initialValues={{ name: "Existing" }}
+      />,
+    );
+
+    const displayNameInput = screen.getByLabelText("Display Name");
+
+    await user.tab();
+
+    expect(displayNameInput).toHaveValue("");
+  });
+
+  it("keeps display name when name is cleared after auto fill", async () => {
+    const user = userEvent.setup();
+    render(<ActivityForm onSubmit={vi.fn()} submitButtonText="Submit" />);
+
+    const nameInput = screen.getByLabelText("Name *");
+    const displayNameInput = screen.getByLabelText("Display Name");
+
+    await user.type(nameInput, "Morning Run");
+    await user.tab();
+
+    expect(displayNameInput).toHaveValue("Morning Run");
+
+    await user.click(nameInput);
+    await user.clear(nameInput);
+    await user.tab();
+
+    expect(displayNameInput).toHaveValue("Morning Run");
+  });
+
+  it("does not overwrite pre-filled display name values", async () => {
+    const user = userEvent.setup();
+    render(
+      <ActivityForm
+        onSubmit={vi.fn()}
+        submitButtonText="Submit"
+        initialValues={{ name: "Morning Run", display_name: "Saved" }}
+      />,
+    );
+
+    const nameInput = screen.getByLabelText("Name *");
+    const displayNameInput = screen.getByLabelText("Display Name");
+
+    await user.click(nameInput);
+    await user.clear(nameInput);
+    await user.type(nameInput, "Updated Name");
+    await user.tab();
+
+    expect(displayNameInput).toHaveValue("Saved");
+  });
+});


### PR DESCRIPTION
## Change Description
- Added functionality to automatically populate `display_name` when `name` is on blur.

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other:

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [x] New tests have been added to cover the changes (if applicable).
- [x] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
