### PR TITLE
[1369] Improve date definition to add tasks today

### DIFF
--- a/src/components/layout/main/Sidebar/links.ts
+++ b/src/components/layout/main/Sidebar/links.ts
@@ -15,7 +15,7 @@ export const sidebarLinks = linkOptions([
     label: "History",
     to: "/history",
     icon: RectangleStackIcon,
-    search: { date: getToday() },
+    search: () => ({ date: getToday() }),
   },
   { label: "Routines", to: "/routines", icon: DocumentTextIcon },
   { label: "Settings", to: "/settings", icon: Cog6ToothIcon },

--- a/src/features/tasks/components/CreateTaskForm.tsx
+++ b/src/features/tasks/components/CreateTaskForm.tsx
@@ -3,7 +3,7 @@ import { useCreateTask } from "../api/tanstack/useCreateTask";
 import { NewTaskForm as FormType } from "../types/newTaskForm";
 import { NewTaskForm } from "./NewTaskForm";
 
-import { parse, set } from "date-fns";
+import { parse, set, startOfToday } from "date-fns";
 import { getRouteApi } from "@tanstack/react-router";
 import { splitHHMM } from "@/utils";
 
@@ -14,7 +14,7 @@ export const CreateTaskForm = () => {
   const { date: dateParam } = routeApi.useSearch();
   const { mutateAsync } = useCreateTask();
 
-  const date = parse(dateParam, "yyyy-MM-dd", new Date());
+  const date = parse(dateParam, "yyyy-MM-dd", startOfToday());
 
   const handleSubmit = async (data: FormType) => {
     const [startHours, startMinutes] = splitHHMM(data.start_time);

--- a/src/pages/Tasks/NewTodayCompletedTaskForm.tsx
+++ b/src/pages/Tasks/NewTodayCompletedTaskForm.tsx
@@ -1,7 +1,7 @@
-import { set } from "date-fns";
+import { set, startOfToday } from "date-fns";
 import { useNavigate } from "@tanstack/react-router";
 
-import { getNewTaskDefaultTimes, getToday, splitHHMM } from "@/utils";
+import { getNewTaskDefaultTimes, splitHHMM } from "@/utils";
 import { NewTaskForm as FormType } from "../../features/tasks/types/newTaskForm";
 import { NewTaskForm } from "../../features/tasks/components/NewTaskForm";
 import { useCreateCompletedTodayTask } from "../../features/tasks/api/tanstack/useCreateCompletedTodayTask";
@@ -15,7 +15,7 @@ export const NewTodayCompletedTaskForm = () => {
   const handleSubmit = (data: FormType) => {
     const [startHours, startMinutes] = splitHHMM(data.start_time);
     const [endHours, endMinutes] = splitHHMM(data.end_time);
-    const today = getToday();
+    const today = startOfToday();
 
     const startTime = set(today, {
       hours: startHours,


### PR DESCRIPTION
## Change Description
- Sidebar: Instead of using a function that is called when the sidebar is rendered. We are now passing a function that will be called when the user clicks on the sidebar.
- Use `startOfToday` instead of `getToday` to get a timezone date that date-fns knows how to properly use.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other:

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
