### PR TITLE
[1515] Add gap between routine name and start time inputs

### DIFF
--- a/src/features/routines/components/EditRoutineForm.tsx
+++ b/src/features/routines/components/EditRoutineForm.tsx
@@ -35,7 +35,7 @@ export const EditRoutineForm = () => {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <div className="flex w-full justify-between">
+      <div className="flex w-full justify-between gap-4">
         <TextInput
           showAsterisk
           hideLabel


### PR DESCRIPTION
## Change Description
- Added `gap-4` to flex container.

## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [x] Refactor
- [ ] Documentation Improvement
- [ ] Other:

## Verification
- [ ] The pull request depends on another pull request
- [ ] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
