### PR TITLE
[1638] Allow users to add future scheduled tasks

### DIFF
--- a/src/features/routines/api/axios/applyRoutine.ts
+++ b/src/features/routines/api/axios/applyRoutine.ts
@@ -6,15 +6,18 @@ import { ROUTINES_ENDPOINT, apiV1 } from "@/libs/axios";
 type ApplyRoutineInput = {
   insertMode: InsertMode;
   routineId: number;
+  scheduledAt?: string;
 };
 
 export const applyRoutine = async ({
   insertMode,
   routineId,
+  scheduledAt,
 }: ApplyRoutineInput) => {
   const URL = `${ROUTINES_ENDPOINT}/${routineId}/apply`;
   const response = await apiV1.post<RoutineWithItems>(URL, {
     insert_mode: insertMode,
+    scheduled_at: scheduledAt,
   });
   return response.data;
 };

--- a/src/features/tasks/api/axios/createScheduledTask.ts
+++ b/src/features/tasks/api/axios/createScheduledTask.ts
@@ -7,15 +7,18 @@ import type { InsertMode } from "../../types/insert-mode";
 type CreateScheduledTaskInput = {
   activity: ActivityWithCategory;
   insertMode: InsertMode;
+  scheduledAt?: string;
 };
 
 export const createScheduledTask = async ({
   activity,
   insertMode,
+  scheduledAt,
 }: CreateScheduledTaskInput) => {
   const response = await apiV1.post<ScheduledTaskAPI>(TASKS_ENDPOINT, {
     activity_id: activity.id,
     insert_mode: insertMode,
+    scheduled_at: scheduledAt,
   });
   return response.data;
 };

--- a/src/features/tasks/api/tanstack/useCreateScheduledTask.ts
+++ b/src/features/tasks/api/tanstack/useCreateScheduledTask.ts
@@ -1,8 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-import { addEnd, addStart } from "@/utils/array";
-import { scheduledTasksQueryOptions, taskKeys } from "../queries";
 import { createScheduledTask } from "../axios/createScheduledTask";
+import { taskKeys } from "../queries";
 
 export const useCreateScheduledTask = () => {
   const queryClient = useQueryClient();
@@ -10,12 +9,7 @@ export const useCreateScheduledTask = () => {
   return useMutation({
     mutationFn: createScheduledTask,
 
-    onSuccess: (newTask, { insertMode }) => {
-      queryClient.setQueryData(scheduledTasksQueryOptions().queryKey, (old) =>
-        insertMode === "prepend"
-          ? addStart(old, newTask)
-          : addEnd(old, newTask),
-      );
+    onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: taskKeys.list({ filter: { status: { eq: "scheduled" } } }),
       });

--- a/src/features/tasks/api/tanstack/useCreateScheduledTask.ts
+++ b/src/features/tasks/api/tanstack/useCreateScheduledTask.ts
@@ -1,8 +1,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { addEnd, addStart } from "@/utils/array";
+import { scheduledTasksQueryOptions, taskKeys } from "../queries";
 import { createScheduledTask } from "../axios/createScheduledTask";
-import { scheduledTasksQueryOptions } from "../queries";
 
 export const useCreateScheduledTask = () => {
   const queryClient = useQueryClient();
@@ -16,7 +16,9 @@ export const useCreateScheduledTask = () => {
           ? addStart(old, newTask)
           : addEnd(old, newTask),
       );
-      queryClient.invalidateQueries(scheduledTasksQueryOptions());
+      queryClient.invalidateQueries({
+        queryKey: taskKeys.list({ filter: { status: { eq: "scheduled" } } }),
+      });
     },
   });
 };

--- a/src/pages/Tasks/AddScheduledTaskMenu.tsx
+++ b/src/pages/Tasks/AddScheduledTaskMenu.tsx
@@ -18,9 +18,10 @@ import clsx from "clsx";
 
 type Props = {
   insertMode: InsertMode;
+  scheduledAt?: string;
 };
 
-export const AddScheduledTaskMenu = ({ insertMode }: Props) => {
+export const AddScheduledTaskMenu = ({ insertMode, scheduledAt }: Props) => {
   const { data: activities } = useQuery(activityListQueryOptions());
   const { data: routines } = useQuery(routineVisibleListQueryOptions());
 
@@ -32,7 +33,7 @@ export const AddScheduledTaskMenu = ({ insertMode }: Props) => {
   const handleApplyRoutine = (routineId: number) => {
     setPendingRoutineId(routineId);
     applyRoutine(
-      { routineId, insertMode },
+      { routineId, insertMode, scheduledAt },
       { onSettled: () => setPendingRoutineId(null) },
     );
   };
@@ -84,7 +85,7 @@ export const AddScheduledTaskMenu = ({ insertMode }: Props) => {
               className="flex w-full items-center justify-between gap-2 px-2 py-1 text-sm font-light data-focus:bg-gray-100"
               onClick={(e) => {
                 e.preventDefault();
-                mutateTask({ activity, insertMode });
+                mutateTask({ activity, insertMode, scheduledAt });
               }}>
               {activity.display_name}{" "}
               <CategoryBadge category={activity.category} />

--- a/src/pages/Tasks/ScheduledTaskListActions.tsx
+++ b/src/pages/Tasks/ScheduledTaskListActions.tsx
@@ -8,7 +8,11 @@ import { AddScheduledTaskMenu } from "./AddScheduledTaskMenu";
 const APPEND_BUTTON_TEXT = "Append new tasks";
 const PREPEND_BUTTON_TEXT = "Prepend new tasks";
 
-export const ScheduledTaskListActions = () => {
+type Props = {
+  scheduledAt?: string;
+};
+
+export const ScheduledTaskListActions = ({ scheduledAt }: Props) => {
   const [insertMode, setInsertMode] = useState<InsertMode>("append");
 
   return (
@@ -35,7 +39,7 @@ export const ScheduledTaskListActions = () => {
         </IconButton>
       )}
 
-      <AddScheduledTaskMenu insertMode={insertMode} />
+      <AddScheduledTaskMenu insertMode={insertMode} scheduledAt={scheduledAt} />
     </div>
   );
 };

--- a/src/routes/__protected/scheduled/route.tsx
+++ b/src/routes/__protected/scheduled/route.tsx
@@ -3,7 +3,7 @@ import { Outlet, createFileRoute } from "@tanstack/react-router";
 import { DateFilter } from "@/components/core/Date";
 import { FutureScheduledTaskList } from "@/pages/Tasks/future-scheduled-task-list";
 import { HeadingLarge } from "@/components/layout";
-import { PlusIcon } from "@heroicons/react/24/solid";
+import { ScheduledTaskListActions } from "@/pages/Tasks/ScheduledTaskListActions";
 
 import { futureTasksQueryOptions } from "@/features/tasks/api/queries";
 import { redirectScheduledPastDate } from "@/utils/taskDateRouting";
@@ -38,10 +38,7 @@ function RouteComponent() {
           className="w-full"
           value={date}
         />
-        <button type="button" disabled>
-          <span className="sr-only">Add Scheduled Task</span>
-          <PlusIcon className="size-5 text-blue-600" aria-hidden />
-        </button>
+        <ScheduledTaskListActions scheduledAt={date} />
       </div>
       <FutureScheduledTaskList />
       <Outlet />

--- a/src/routes/__protected/scheduled/route.tsx
+++ b/src/routes/__protected/scheduled/route.tsx
@@ -6,6 +6,7 @@ import { HeadingLarge } from "@/components/layout";
 import { ScheduledTaskListActions } from "@/pages/Tasks/ScheduledTaskListActions";
 
 import { futureTasksQueryOptions } from "@/features/tasks/api/queries";
+import { localDateToUtc } from "@/utils/dateConversion";
 import { redirectScheduledPastDate } from "@/utils/taskDateRouting";
 import { validateDateSearch } from "@/utils/search";
 
@@ -26,6 +27,7 @@ export const Route = createFileRoute("/__protected/scheduled")({
 
 function RouteComponent() {
   const { date } = Route.useSearch();
+  const scheduledAt = localDateToUtc(date);
 
   return (
     <div>
@@ -38,7 +40,7 @@ function RouteComponent() {
           className="w-full"
           value={date}
         />
-        <ScheduledTaskListActions scheduledAt={date} />
+        <ScheduledTaskListActions scheduledAt={scheduledAt} />
       </div>
       <FutureScheduledTaskList />
       <Outlet />


### PR DESCRIPTION
## Change Description
- [ ] `createScheduledTask.ts` — accepts optional `scheduledAt` and sends it.
- [ ] `applyRoutine.ts` — accepts optional `scheduledAt`, sends it.
- [ ] `useCreateScheduledTask.ts` — broadened invalidation to match all scheduled-status task lists.
- [ ] `AddScheduledTaskMenu.tsx` — accepts optional `scheduledAt` prop.
- [ ] `ScheduledTaskListActions.tsx` — accepts optional `scheduledAt` prop.
- [ ] `scheduled/route.tsx` — replaced disabled plus button with `ScheduledTaskListActions`, wired with `date` from URL

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor
- [ ] Documentation Improvement
- [ ] Other:

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
