### PR TITLE
[1691] Increase notes limit to 2000 chars

### DIFF
--- a/src/features/tasks/components/CompletedTaskForm.tsx
+++ b/src/features/tasks/components/CompletedTaskForm.tsx
@@ -40,11 +40,11 @@ export const CompletedTaskForm = ({ initialValues, task, onSubmit }: Props) => {
         rows={4}
         registration={register("note", {
           maxLength: {
-            value: 250,
-            message: "Note cannot exceed 250 characters.",
+            value: 2000,
+            message: "Note cannot exceed 2000 characters.",
           },
         })}
-        description="Max 250 characters"
+        description="Max 2000 characters"
         error={errors.note?.message}
       />
 

--- a/src/features/tasks/components/InProgressTaskForm.tsx
+++ b/src/features/tasks/components/InProgressTaskForm.tsx
@@ -49,11 +49,11 @@ export const InProgressTaskForm = ({
         rows={4}
         registration={register("note", {
           maxLength: {
-            value: 250,
-            message: "Note cannot exceed 250 characters.",
+            value: 2000,
+            message: "Note cannot exceed 2000 characters.",
           },
         })}
-        description="Max 250 characters"
+        description="Max 2000 characters"
         error={errors.note?.message}
       />
 

--- a/src/features/tasks/components/NewTaskForm.tsx
+++ b/src/features/tasks/components/NewTaskForm.tsx
@@ -40,11 +40,11 @@ export const NewTaskForm = ({ initialValues, onSubmit }: Props) => {
         autoComplete="off"
         registration={register("note", {
           maxLength: {
-            value: 250,
-            message: "Max 250 characters",
+            value: 2000,
+            message: "Max 2000 characters",
           },
         })}
-        description="Max 250 characters"
+        description="Max 2000 characters"
         error={errors.note?.message}
       />
 

--- a/src/features/tasks/components/ScheduledTaskForm.tsx
+++ b/src/features/tasks/components/ScheduledTaskForm.tsx
@@ -69,11 +69,11 @@ export const ScheduledTaskForm = ({ initialValues, task, onSubmit }: Props) => {
         rows={4}
         registration={register("note", {
           maxLength: {
-            value: 250,
-            message: "Note cannot exceed 250 characters.",
+            value: 2000,
+            message: "Note cannot exceed 2000 characters.",
           },
         })}
-        description="Max 250 characters"
+        description="Max 2000 characters"
         error={errors.note?.message}
       />
 


### PR DESCRIPTION
## Change Description
- This pull request increases the maximum allowed length for the `note` field in all task-related forms from 250 to 2000 characters. This change applies to the new, in-progress, scheduled, and completed task forms, updating both the validation logic and the user-facing descriptions.

## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [x] Refactor
- [ ] Documentation Improvement
- [ ] Other:

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
