### PR TITLE
[c-1695] Allow multiple id params

### DIFF
--- a/src/utils/array/__tests__/removeById.spec.ts
+++ b/src/utils/array/__tests__/removeById.spec.ts
@@ -39,4 +39,41 @@ describe("removeById", () => {
     expect(result).toEqual(list);
     expect(result).not.toBe(list);
   });
+
+  it("removes multiple items when given multiple ids", () => {
+    const list = [
+      { id: 1, name: "a" },
+      { id: 2, name: "b" },
+      { id: 3, name: "c" },
+      { id: 4, name: "d" },
+    ];
+    const result = removeById(list, 2, 4);
+    expect(result).toEqual([
+      { id: 1, name: "a" },
+      { id: 3, name: "c" },
+    ]);
+  });
+
+  it("returns full copy when no ids are passed", () => {
+    const list = [
+      { id: 1, name: "a" },
+      { id: 2, name: "b" },
+    ];
+    const result = removeById(list);
+    expect(result).toEqual(list);
+    expect(result).not.toBe(list);
+  });
+
+  it("removes only the found ids when mixed with missing ones", () => {
+    const list = [
+      { id: 1, name: "a" },
+      { id: 2, name: "b" },
+      { id: 3, name: "c" },
+    ];
+    const result = removeById(list, 2, 999);
+    expect(result).toEqual([
+      { id: 1, name: "a" },
+      { id: 3, name: "c" },
+    ]);
+  });
 });

--- a/src/utils/array/removeById.ts
+++ b/src/utils/array/removeById.ts
@@ -1,6 +1,12 @@
 interface RemoveById {
-  <T extends { id: number | string }>(list: T[] | undefined, id: T["id"]): T[];
+  <T extends { id: number | string }>(
+    list: T[] | undefined,
+    ...ids: T["id"][]
+  ): T[];
 }
 
-export const removeById: RemoveById = (list, id) =>
-  list ? list.filter((item) => item.id !== id) : [];
+export const removeById: RemoveById = (list, ...ids) => {
+  if (!list) return [];
+  const idSet = new Set(ids);
+  return list.filter((item) => !idSet.has(item.id));
+};


### PR DESCRIPTION
## Change Description
-  Modified `removeById` to accept several Id params, making it more useful for different cases.

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [x] Refactor
- [ ] Documentation Improvement
- [ ] Other:

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [x] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
