### PR TITLE
[1755] Dropping eslint-plugin-jest-dom

### DIFF
--- a/.claude/skills/jest-dom-assertions/SKILL.md
+++ b/.claude/skills/jest-dom-assertions/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: jest-dom-assertions
+description: >-
+  Use when writing or reviewing React component tests that assert on DOM state
+  (Testing Library + @testing-library/jest-dom matchers). Trigger on: authoring
+  a *.spec.tsx / *.test.tsx, "write a test for this component", "assert the
+  button is disabled/checked/in the document", reviewing test assertions, or any
+  expect(...) on a queried element. Enforces jest-dom matchers over raw
+  DOM/attribute/property checks (toBeInTheDocument, toBeChecked, toHaveValue,
+  toHaveAttribute, toHaveFocus, …). This is the in-house replacement for
+  eslint-plugin-jest-dom. Do NOT trigger for: query selection strategy /
+  getBy-vs-findBy / async waiting (that is testing-library plugin territory),
+  non-DOM unit tests, hook tests with no rendered element, or test-runner config.
+---
+
+# jest-dom Assertions
+
+`@testing-library/jest-dom` ships matchers that read intent directly off the
+element. Prefer them over poking at attributes, properties, or the raw DOM — the
+matcher gives a clearer failure message and survives DOM/ARIA details changing.
+
+Matchers are auto-registered via `src/test/setup.ts`, so just use them. Tests run
+on Vitest; `expect`/`screen` are global.
+
+## The rule: assert through the element, not its internals
+
+For every check below, the ❌ form works but reads poorly and gives a worse diff
+on failure. Always write the ✅ form.
+
+### Presence / absence
+
+```ts
+// ❌ length / null / defined / truthy checks on a query
+expect(screen.queryByText("Save")).not.toBeNull();
+expect(screen.queryAllByRole("row")).toHaveLength(1);
+expect(screen.queryByText("Gone")).toBeNull();
+// ✅
+expect(screen.getByText("Save")).toBeInTheDocument();
+expect(screen.queryByText("Gone")).not.toBeInTheDocument();
+```
+
+Use `queryBy*` (not `getBy*`) when asserting something is **absent** — `getBy*`
+throws before the assertion runs.
+
+### Checked / disabled / required
+
+```ts
+// ❌
+expect(input).toHaveProperty("checked", true);
+expect(input).toHaveAttribute("disabled");
+expect(input).toHaveAttribute("required");
+// ✅
+expect(input).toBeChecked();
+expect(input).toBeDisabled(); // toBeEnabled() for the negative
+expect(input).toBeRequired();
+```
+
+### Value
+
+```ts
+// ❌
+expect(input.value).toBe("hello");
+expect(input).toHaveAttribute("value", "hello");
+// ✅
+expect(input).toHaveValue("hello");
+```
+
+### Focus
+
+```ts
+// ❌
+expect(document.activeElement).toBe(input);
+// ✅
+expect(input).toHaveFocus();
+```
+
+### Attributes
+
+```ts
+// ❌
+expect(link.getAttribute("href")).toBe("/home");
+expect(el.hasAttribute("aria-hidden")).toBe(true);
+// ✅
+expect(link).toHaveAttribute("href", "/home");
+expect(el).toHaveAttribute("aria-hidden");
+```
+
+### Class / style / text / empty
+
+```ts
+// ❌
+expect(el.className).toBe("btn active");
+expect(el.style.color).toBe("red");
+expect(el.textContent).toBe("Total");
+expect(el.innerHTML).toBe("");
+// ✅
+expect(el).toHaveClass("btn", "active");
+expect(el).toHaveStyle({ color: "red" });
+expect(el).toHaveTextContent("Total"); // accepts string or RegExp
+expect(el).toBeEmptyDOMElement();
+```
+
+## Quick reference
+
+| Instead of…                                                                       | Use                                               |
+| --------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `.toHaveLength(0/1)`, `.toBeNull()`, `.toBeDefined()`, `.toBeTruthy()` on a query | `toBeInTheDocument()` / `not.toBeInTheDocument()` |
+| `toHaveProperty/Attribute("checked")`                                             | `toBeChecked()`                                   |
+| `toHaveAttribute("disabled")`                                                     | `toBeDisabled()` / `toBeEnabled()`                |
+| `toHaveProperty/Attribute("required")`                                            | `toBeRequired()`                                  |
+| `.value` / `toHaveAttribute("value", …)`                                          | `toHaveValue()`                                   |
+| `document.activeElement` comparisons                                              | `toHaveFocus()`                                   |
+| `getAttribute()` / `hasAttribute()` assertions                                    | `toHaveAttribute()`                               |
+| `.className` / `.classList` checks                                                | `toHaveClass()`                                   |
+| `.style.*` checks                                                                 | `toHaveStyle()`                                   |
+| `.textContent` checks                                                             | `toHaveTextContent()`                             |
+| `.innerHTML === ""` / `firstChild === null`                                       | `toBeEmptyDOMElement()`                           |

--- a/.claude/skills/jest-dom-assertions/SKILL.md
+++ b/.claude/skills/jest-dom-assertions/SKILL.md
@@ -20,7 +20,7 @@ element. Prefer them over poking at attributes, properties, or the raw DOM — t
 matcher gives a clearer failure message and survives DOM/ARIA details changing.
 
 Matchers are auto-registered via `src/test/setup.ts`, so just use them. Tests run
-on Vitest; `expect`/`screen` are global.
+on Vitest; `expect` is global; import `screen` from `@testing-library/react` (or `src/test/test-utils`).
 
 ## The rule: assert through the element, not its internals
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,6 @@ import eslintConfigPrettier from "eslint-config-prettier";
 import pluginReactHooks from "eslint-plugin-react-hooks";
 import reactCompiler from "eslint-plugin-react-compiler";
 import reactRefresh from "eslint-plugin-react-refresh";
-import jestDom from 'eslint-plugin-jest-dom';
 import pluginRouter from '@tanstack/eslint-plugin-router'
 
 /** @type {import('eslint').Linter.Config[]} */
@@ -19,10 +18,6 @@ export default [
   {
     files: ["**/*.spec.{ts,tsx}", "**/*.test.{ts,tsx}"],
     ...testingLibrary.configs["flat/react"],
-  },
-  {
-    files: ["**/*.spec.{tsx,ts}"],
-    ...jestDom.configs['flat/recommended'],
   },
   {
     plugins: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
         "baseline-browser-mapping": "^2.10.33",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-jest-dom": "^5.5.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-compiler": "^19.0.0-beta-714736e-20250131",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -5091,31 +5090,6 @@
         "eslint": ">=7.0.0"
       }
     },
-    "node_modules/eslint-plugin-jest-dom": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest-dom/-/eslint-plugin-jest-dom-5.5.0.tgz",
-      "integrity": "sha512-CRlXfchTr7EgC3tDI7MGHY6QjdJU5Vv2RPaeeGtkXUHnKZf04kgzMPIJUXt4qKCvYWVVIEo9ut9Oq1vgXAykEA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.16.3",
-        "requireindex": "^1.2.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0",
-        "npm": ">=6",
-        "yarn": ">=1"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "eslint": "^6.8.0 || ^7.0.0 || ^8.0.0 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@testing-library/dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
@@ -8186,16 +8160,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/requireindex": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
-      "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.5"
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "baseline-browser-mapping": "^2.10.33",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-jest-dom": "^5.5.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-compiler": "^19.0.0-beta-714736e-20250131",
     "eslint-plugin-react-hooks": "^7.0.1",


### PR DESCRIPTION
## Change Description
- Dropping `eslint-plugin-jest-dom` in favor of Agent skills.

## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [x] Documentation Improvement
- [ ] Other:

## Verification
- [ ] The pull request depends on another pull request
- [x] All existing tests pass after the changes.
- [ ] New tests have been added to cover the changes (if applicable).
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] The feature works as expected and meets the acceptance criteria.
